### PR TITLE
Add user login and editable exercise catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,10 @@ Aplicación sencilla en Streamlit para registrar entrenamientos de gimnasio y ca
 - Exportación e importación de datos para sincronizar con otras plataformas.
 - Manejo correcto de fechas incluso si los registros usan números de día.
 
+
+## Reiniciar datos de usuarios
+Si deseas borrar la información de usuarios registrada, ejecuta:
+```bash
+python reset_data.py
+```
+Se generará un archivo `data/Usuarios.csv` vacío con solo las cabeceras.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Gym & Running Tracker
+
+Aplicación sencilla en Streamlit para registrar entrenamientos de gimnasio y carreras.
+
+## Uso
+
+1. Instalar dependencias:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Ejecutar con Streamlit:
+   ```bash
+   streamlit run main.py
+   ```
+
+## Características
+- Registro y autenticación de usuarios.
+- Catálogo editable de ejercicios de gimnasio y running.
+- Registro diario con peso (kg/lb), repeticiones, series y distancia.
+- Paneles de progreso con gráficas semanales y mensuales, comparativas y proyecciones de fuerza.
+

--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ Aplicación sencilla en Streamlit para registrar entrenamientos de gimnasio y ca
 - Inicio de sesión y registro en pestañas para una mejor experiencia.
 - Catálogo editable de ejercicios de gimnasio y running.
 - Registro diario con peso (kg/lb), repeticiones, series y distancia.
-- Paneles de progreso interactivos con gráficas semanales y mensuales, comparativas y proyecciones de fuerza.
-- Filtros por rango de fechas y gráficos de peso promedio semanal.
+- Paneles de progreso interactivos con métricas ejecutivas (volumen, distancia y sesiones) y comparativas entre usuarios.
+- Filtros rápidos Hoy/7 días/30 días o personalizado para cambiar todas las gráficas.
+- Gráficos de peso promedio, volumen por grupo muscular y distancia semanal.
 - Barras de volumen por ejercicio y por grupo muscular.
 - Recordatorios de entrenamiento desde la barra lateral.
 - Carga de rutas GPX/CSV y mapa de recorridos para carreras.

--- a/README.md
+++ b/README.md
@@ -25,4 +25,5 @@ Aplicación sencilla en Streamlit para registrar entrenamientos de gimnasio y ca
 - Recordatorios de entrenamiento desde la barra lateral.
 - Carga de rutas GPX/CSV y mapa de recorridos para carreras.
 - Exportación e importación de datos para sincronizar con otras plataformas.
+- Manejo correcto de fechas incluso si los registros usan números de día.
 

--- a/README.md
+++ b/README.md
@@ -18,4 +18,7 @@ Aplicación sencilla en Streamlit para registrar entrenamientos de gimnasio y ca
 - Catálogo editable de ejercicios de gimnasio y running.
 - Registro diario con peso (kg/lb), repeticiones, series y distancia.
 - Paneles de progreso con gráficas semanales y mensuales, comparativas y proyecciones de fuerza.
+- Recordatorios de entrenamiento desde la barra lateral.
+- Carga de rutas GPX/CSV y mapa de recorridos para carreras.
+- Exportación e importación de datos para sincronizar con otras plataformas.
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Aplicación sencilla en Streamlit para registrar entrenamientos de gimnasio y ca
 - Catálogo editable de ejercicios de gimnasio y running.
 - Registro diario con peso (kg/lb), repeticiones, series y distancia.
 - Paneles de progreso interactivos con gráficas semanales y mensuales, comparativas y proyecciones de fuerza.
+- Filtros por rango de fechas y gráficos de peso promedio semanal.
+- Barras de volumen por ejercicio y por grupo muscular.
 - Recordatorios de entrenamiento desde la barra lateral.
 - Carga de rutas GPX/CSV y mapa de recorridos para carreras.
 - Exportación e importación de datos para sincronizar con otras plataformas.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Aplicación sencilla en Streamlit para registrar entrenamientos de gimnasio y ca
 - Catálogo editable de ejercicios de gimnasio y running.
 - Registro diario con peso (kg/lb), repeticiones, series y distancia.
 - Paneles de progreso interactivos con métricas ejecutivas (volumen, distancia y sesiones) y comparativas entre usuarios.
+- Indicador de consistencia con promedio de días entrenados por semana.
 - Filtros rápidos Hoy/7 días/30 días o personalizado para cambiar todas las gráficas.
 - Gráficos de peso promedio, volumen por grupo muscular y distancia semanal.
 - Barras de volumen por ejercicio y por grupo muscular.

--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ Aplicación sencilla en Streamlit para registrar entrenamientos de gimnasio y ca
 
 ## Características
 - Registro y autenticación de usuarios.
+- Inicio de sesión y registro en pestañas para una mejor experiencia.
 - Catálogo editable de ejercicios de gimnasio y running.
 - Registro diario con peso (kg/lb), repeticiones, series y distancia.
-- Paneles de progreso con gráficas semanales y mensuales, comparativas y proyecciones de fuerza.
+- Paneles de progreso interactivos con gráficas semanales y mensuales, comparativas y proyecciones de fuerza.
 - Recordatorios de entrenamiento desde la barra lateral.
 - Carga de rutas GPX/CSV y mapa de recorridos para carreras.
 - Exportación e importación de datos para sincronizar con otras plataformas.

--- a/README.md
+++ b/README.md
@@ -17,13 +17,18 @@ Aplicación sencilla en Streamlit para registrar entrenamientos de gimnasio y ca
 - Registro y autenticación de usuarios.
 - Inicio de sesión y registro en pestañas para una mejor experiencia.
 - Catálogo editable de ejercicios de gimnasio y running.
-- Registro diario con peso (kg/lb), repeticiones, series y distancia.
+- Registro diario con peso (kg/lb), repeticiones, series, distancia y notas.
+- Historial de sesiones para revisar semanas previas.
 - Paneles de progreso interactivos con métricas ejecutivas (volumen, distancia y sesiones) y comparativas entre usuarios.
 - Indicador de consistencia con promedio de días entrenados por semana.
 - Filtros rápidos Hoy/7 días/30 días o personalizado para cambiar todas las gráficas.
 - Gráficos de peso promedio, volumen por grupo muscular y distancia semanal.
 - Barras de volumen por ejercicio y por grupo muscular.
 - Recordatorios de entrenamiento desde la barra lateral.
+- Temporizador de descanso configurable.
+- Calendario de entrenamiento con frecuencia semanal.
+- Registro de peso corporal y medidas con gráficas.
+- Soporte para rutinas personalizadas y marcarlas como completadas.
 - Carga de rutas GPX/CSV y mapa de recorridos para carreras.
 - Exportación e importación de datos para sincronizar con otras plataformas.
 - Manejo correcto de fechas incluso si los registros usan números de día.

--- a/data/Grupo_muscular.csv
+++ b/data/Grupo_muscular.csv
@@ -1,10 +1,12 @@
-Grupo_Muscular,Ejercicio
-Pectorales hombros y triceps,Press de pecho
-Pectorales hombros y triceps,Extensión de hombro
-Pectorales hombros y triceps,Extensión de tríceps en polea
-Pectorales hombros y triceps,Extensión lateral
-Pectorales hombros y triceps,Extensión frontal
-Gluteos y femorales,Peso muerto
-Gluteos y femorales,Leg Curl
-Gluteos y femorales,Abducción
-Gluteos y femorales,Glúteo en maquina
+Grupo_Muscular,Ejercicio,Tipo
+Pectorales hombros y triceps,Press de pecho,Gimnasio
+Pectorales hombros y triceps,Extensión de hombro,Gimnasio
+Pectorales hombros y triceps,Extensión de tríceps en polea,Gimnasio
+Pectorales hombros y triceps,Extensión lateral,Gimnasio
+Pectorales hombros y triceps,Extensión frontal,Gimnasio
+Gluteos y femorales,Peso muerto,Gimnasio
+Gluteos y femorales,Leg Curl,Gimnasio
+Gluteos y femorales,Abducción,Gimnasio
+Gluteos y femorales,Glúteo en maquina,Gimnasio
+Cardio,Correr,Carrera
+Cardio,Trote,Carrera

--- a/data/Grupo_muscular.csv
+++ b/data/Grupo_muscular.csv
@@ -1,21 +1,10 @@
-﻿Grupo_Muscular,Maquina,,,,,
-Pectorales hombros y triceps,Press de pecho,,,,,
-Pectorales hombros y triceps,Extensión de hombro,,,,,
-Pectorales hombros y triceps,Extensión de tríceps en polea,,,,,
-Pectorales hombros y triceps,Extensión lateral,,,,,
-Pectorales hombros y triceps,Extensión frontal,,,,,
-Gluteos y femorales,Peso muerto,,,,,
-Gluteos y femorales,Leg Curl,,,,,
-Gluteos y femorales,Abducción,,,,,
-Gluteos y femorales,Glúteo en maquina,,,,,
-Cuadriceps,Leg press,,,,,
-Cuadriceps,Hack squat,,,,,
-Cuadriceps,Aducción,,,,,
-Cuadriceps,Leg extension,,,,,
-Espalda y Biceps,Jalón polea alta prono,,,,,
-Espalda y Biceps,Jalón polea alta supino,,,,,
-Espalda y Biceps,Remo sentado con polea,,,,,
-Espalda y Biceps,Curl biceps,,,,,
-Espalda y Biceps,Curl martillo,,,,,
-Gluteos y femorales,Hip thrust,,,,,
-Cuadriceps,Sentadilla,,,,,
+Grupo_Muscular,Ejercicio
+Pectorales hombros y triceps,Press de pecho
+Pectorales hombros y triceps,Extensión de hombro
+Pectorales hombros y triceps,Extensión de tríceps en polea
+Pectorales hombros y triceps,Extensión lateral
+Pectorales hombros y triceps,Extensión frontal
+Gluteos y femorales,Peso muerto
+Gluteos y femorales,Leg Curl
+Gluteos y femorales,Abducción
+Gluteos y femorales,Glúteo en maquina

--- a/data/Peso.csv
+++ b/data/Peso.csv
@@ -1,0 +1,1 @@
+Id_Usuario,Fecha,Peso,Cintura,Pecho,Foto

--- a/data/Progreso.csv
+++ b/data/Progreso.csv
@@ -1,160 +1,160 @@
-Dia,Id_Usuario,Ejercicio,Peso,Sets,Repeticiones
-1,C1,Press de pecho,26,1,15
-1,C1,Press de pecho,33,2,15
-1,C1,Press de pecho,38,1,15
-1,C2,Press de pecho,5,1,15
-1,C2,Press de pecho,12,3,15
-1,C1,Extensión de hombro,15,3,15
-1,C2,Extensión de hombro,5,3,15
-1,C1,Extensión de tríceps en polea,13.75,1,15
-1,C1,Extensión de tríceps en polea,16.25,3,15
-1,C2,Extensión de tríceps en polea,6.25,4,15
-1,C1,Extensión lateral,6.25,3,10
-1,C2,Extensión lateral,1.25,3,10
-1,C1,Extensión frontal,3.75,3,10
-1,C2,Extensión frontal,1.25,3,10
-2,C1,Peso muerto,22,4,15
-2,C1,Leg Curl,47.5,4,20
-2,C1,Abducción,50,1,20
-2,C1,Abducción,60,1,20
-2,C1,Abducción,70,1,20
-2,C1,Abducción,80,1,20
-2,C1,Glúteo en maquina,30,1,15
-2,C1,Glúteo en maquina,32.5,1,15
-2,C1,Glúteo en maquina,35,1,15
-2,C2,Peso muerto,10,4,15
-2,C2,Leg Curl,17.5,1,20
-2,C2,Leg Curl,20,3,20
-2,C2,Abducción,27.5,1,15
-2,C2,Abducción,30,2,15
-2,C2,Abducción,35,1,15
-2,C2,Glúteo en maquina,20,3,15
-3,C1,Leg press,80,4,20
-3,C1,Hack squat,40,4,15
-3,C1,Aducción,80,4,20
-3,C1,Leg extension,80,4,20
-4,C1,Jalón polea alta prono,33,4,15
-4,C1,Jalón polea alta supino,33,4,15
-4,C1,Remo sentado con polea,65,4,15
-4,C1,Curl biceps,10,4,10
-4,C1,Curl martillo,7,4,10
-5,C1,Abducción,80,4,20
-5,C1,Glúteo en maquina,40,3,15
-5,C1,Hip thrust,15,2,15
-5,C1,Hip thrust,20,2,15
-5,C1,Leg Curl,42.5,3,20
-5,C1,Peso muerto,22,3,15
-3,C2,Abducción,35,1,20
-3,C2,Abducción,40,2,20
-3,C2,Abducción,42.5,1,20
-3,C2,Glúteo en maquina,20,1,15
-3,C2,Glúteo en maquina,25,2,15
-3,C2,Hip thrust,5,1,15
-3,C2,Hip thrust,10,3,15
-3,C2,Leg Curl,15,3,15
-3,C2,Peso muerto,12,3,15
-6,C1,Leg extension,80,4,20
-6,C1,Leg press,80,4,20
-6,C1,Aducción,80,4,20
-7,C1,Press de pecho,40,4,20
-7,C1,Extensión de hombro,26,4,15
-7,C1,Extensión de tríceps en polea,27.5,4,15
-7,C1,Extensión lateral,7.5,3,15
-7,C1,Extensión frontal,4,1,15
-7,C1,Extensión frontal,7.5,2,15
-8,C1,Jalón polea alta prono,31.75,4,15
-8,C1,Jalón polea alta supino,31.75,4,15
-8,C1,Remo sentado con polea,65,4,15
-8,C1,Curl biceps,6,4,15
-8,C1,Curl martillo,6,4,15
-9,C1,Jalón polea alta prono,33,3,15
-9,C1,Jalón polea alta prono,40,1,15
-9,C1,Jalón polea alta supino,33,3,15
-9,C1,Jalón polea alta supino,40,1,15
-9,C1,Remo sentado con polea,65,4,15
-9,C1,Curl biceps,10,4,15
-9,C1,Curl martillo,7,4,15
-10,C1,Leg press,80,4,20
-10,C1,Hack squat,40,4,15
-10,C1,Aducción,79.37,4,20
-10,C1,Leg extension,36.28,4,20
-11,C1,Press de pecho,40,4,20
-11,C1,Extensión de hombro,25,4,15
-11,C1,Extensión de tríceps en polea,13.75,1,15
-11,C1,Extensión de tríceps en polea,16.25,3,15
-11,C1,Extensión lateral,6.25,3,15
-11,C1,Extensión frontal,6.25,1,15
-12,C1,Peso muerto,22,4,15
-12,C1,Leg Curl,47.62,4,20
-12,C1,Abducción,81.64,4,20
-12,C1,Glúteo en maquina,40,1,15
-12,C1,Glúteo en maquina,42.5,2,15
-13,C1,Jalón polea alta prono,28.5,4,15
-13,C1,Jalón polea alta supino,28.5,4,15
-13,C1,Remo sentado con polea,42.5,4,15
-13,C1,Curl biceps,10,3,10
-13,C1,Curl martillo,6,3,10
-14,C1,Leg press,50,4,20
-14,C1,Sentadilla,15,1,15
-14,C1,Sentadilla,20,1,15
-14,C1,Sentadilla,25,2,8
-14,C1,Aducción,105,4,20
-14,C1,Leg extension,105,4,20
-15,C1,Press de pecho,12,4,20
-15,C1,Extensión de hombro,15,4,15
-15,C1,Extensión de tríceps en polea,11.25,4,15
-15,C1,Extensión lateral,3.75,3,15
-15,C1,Extensión frontal,3.75,3,15
-16,C1,Peso muerto,22,4,15
-16,C1,Leg Curl,65,4,20
-16,C1,Hip thrust,20,4,15
-16,C1,Abducción,105,4,20
-16,C1,Glúteo en maquina,25,3,15
-17,C1,Abducción,175,1,20
-17,C1,Abducción,190,1,15
-17,C1,Abducción,205,1,12
-17,C1,Abducción,220,1,10
-17,C1,Hack squat,20,1,20
-17,C1,Hack squat,30,1,15
-17,C1,Hack squat,40,1,12
-17,C1,Hack squat,50,1,10
-17,C1,Leg press,70,1,20
-17,C1,Leg press,80,1,15
-17,C1,Leg press,90,1,12
-17,C1,Leg press,100,1,10
-17,C1,Leg extension,105,1,20
-17,C1,Leg extension,115,1,15
-17,C1,Leg extension,130,1,12
-17,C1,Leg extension,145,1,10
-18,C1,Remo sentado con polea,28.75,1,20
-18,C1,Remo sentado con polea,31.25,1,15
-18,C1,Remo sentado con polea,33.75,1,12
-18,C1,Remo sentado con polea,36.25,1,10
-18,C1,Jalón polea alta prono,33,4,15
-18,C1,Jalón polea alta supino,33,4,15
-18,C1,Curl biceps,10,3,20
-18,C1,Curl martillo,9,3,10
-19,C1,Peso muerto,22,4,15
-19,C1,Leg Curl,105,1,20
-19,C1,Leg Curl,115,1,15
-19,C1,Leg Curl,130,1,12
-19,C1,Leg Curl,145,1,10
-19,C1,Hip thrust,20,3,15
-19,C1,Abducción,175,1,20
-19,C1,Abducción,190,1,15
-19,C1,Abducción,205,1,12
-19,C1,Abducción,220,1,10
-19,C1,Glúteo en maquina,42.5,1,15
-19,C1,Glúteo en maquina,47.5,1,12
-19,C1,Glúteo en maquina,52.5,1,10
-20,C1,Press de pecho,19,1,20
-20,C1,Press de pecho,26,1,15
-20,C1,Press de pecho,33,1,12
-20,C1,Press de pecho,40,1,10
-20,C1,Extensión de hombro,25,1,20
-20,C1,Extensión de hombro,35,1,15
-20,C1,Extensión de hombro,45,1,12
-20,C1,Extensión de hombro,50,1,10
-20,C1,Extensión de tríceps en polea,11.25,4,15
-20,C1,Extensión lateral,3.75,3,15
-20,C1,Extensión frontal,3.75,3,15
+Dia,Id_Usuario,Ejercicio,Peso,Sets,Repeticiones,Unidad,Distancia,Tipo,Tiempo
+1,C1,Press de pecho,26,1,15,kg,,Gimnasio,
+1,C1,Press de pecho,33,2,15,kg,,Gimnasio,
+1,C1,Press de pecho,38,1,15,kg,,Gimnasio,
+1,C2,Press de pecho,5,1,15,kg,,Gimnasio,
+1,C2,Press de pecho,12,3,15,kg,,Gimnasio,
+1,C1,Extensión de hombro,15,3,15,kg,,Gimnasio,
+1,C2,Extensión de hombro,5,3,15,kg,,Gimnasio,
+1,C1,Extensión de tríceps en polea,13.75,1,15,kg,,Gimnasio,
+1,C1,Extensión de tríceps en polea,16.25,3,15,kg,,Gimnasio,
+1,C2,Extensión de tríceps en polea,6.25,4,15,kg,,Gimnasio,
+1,C1,Extensión lateral,6.25,3,10,kg,,Gimnasio,
+1,C2,Extensión lateral,1.25,3,10,kg,,Gimnasio,
+1,C1,Extensión frontal,3.75,3,10,kg,,Gimnasio,
+1,C2,Extensión frontal,1.25,3,10,kg,,Gimnasio,
+2,C1,Peso muerto,22,4,15,kg,,Gimnasio,
+2,C1,Leg Curl,47.5,4,20,kg,,Gimnasio,
+2,C1,Abducción,50,1,20,kg,,Gimnasio,
+2,C1,Abducción,60,1,20,kg,,Gimnasio,
+2,C1,Abducción,70,1,20,kg,,Gimnasio,
+2,C1,Abducción,80,1,20,kg,,Gimnasio,
+2,C1,Glúteo en maquina,30,1,15,kg,,Gimnasio,
+2,C1,Glúteo en maquina,32.5,1,15,kg,,Gimnasio,
+2,C1,Glúteo en maquina,35,1,15,kg,,Gimnasio,
+2,C2,Peso muerto,10,4,15,kg,,Gimnasio,
+2,C2,Leg Curl,17.5,1,20,kg,,Gimnasio,
+2,C2,Leg Curl,20,3,20,kg,,Gimnasio,
+2,C2,Abducción,27.5,1,15,kg,,Gimnasio,
+2,C2,Abducción,30,2,15,kg,,Gimnasio,
+2,C2,Abducción,35,1,15,kg,,Gimnasio,
+2,C2,Glúteo en maquina,20,3,15,kg,,Gimnasio,
+3,C1,Leg press,80,4,20,kg,,Gimnasio,
+3,C1,Hack squat,40,4,15,kg,,Gimnasio,
+3,C1,Aducción,80,4,20,kg,,Gimnasio,
+3,C1,Leg extension,80,4,20,kg,,Gimnasio,
+4,C1,Jalón polea alta prono,33,4,15,kg,,Gimnasio,
+4,C1,Jalón polea alta supino,33,4,15,kg,,Gimnasio,
+4,C1,Remo sentado con polea,65,4,15,kg,,Gimnasio,
+4,C1,Curl biceps,10,4,10,kg,,Gimnasio,
+4,C1,Curl martillo,7,4,10,kg,,Gimnasio,
+5,C1,Abducción,80,4,20,kg,,Gimnasio,
+5,C1,Glúteo en maquina,40,3,15,kg,,Gimnasio,
+5,C1,Hip thrust,15,2,15,kg,,Gimnasio,
+5,C1,Hip thrust,20,2,15,kg,,Gimnasio,
+5,C1,Leg Curl,42.5,3,20,kg,,Gimnasio,
+5,C1,Peso muerto,22,3,15,kg,,Gimnasio,
+3,C2,Abducción,35,1,20,kg,,Gimnasio,
+3,C2,Abducción,40,2,20,kg,,Gimnasio,
+3,C2,Abducción,42.5,1,20,kg,,Gimnasio,
+3,C2,Glúteo en maquina,20,1,15,kg,,Gimnasio,
+3,C2,Glúteo en maquina,25,2,15,kg,,Gimnasio,
+3,C2,Hip thrust,5,1,15,kg,,Gimnasio,
+3,C2,Hip thrust,10,3,15,kg,,Gimnasio,
+3,C2,Leg Curl,15,3,15,kg,,Gimnasio,
+3,C2,Peso muerto,12,3,15,kg,,Gimnasio,
+6,C1,Leg extension,80,4,20,kg,,Gimnasio,
+6,C1,Leg press,80,4,20,kg,,Gimnasio,
+6,C1,Aducción,80,4,20,kg,,Gimnasio,
+7,C1,Press de pecho,40,4,20,kg,,Gimnasio,
+7,C1,Extensión de hombro,26,4,15,kg,,Gimnasio,
+7,C1,Extensión de tríceps en polea,27.5,4,15,kg,,Gimnasio,
+7,C1,Extensión lateral,7.5,3,15,kg,,Gimnasio,
+7,C1,Extensión frontal,4,1,15,kg,,Gimnasio,
+7,C1,Extensión frontal,7.5,2,15,kg,,Gimnasio,
+8,C1,Jalón polea alta prono,31.75,4,15,kg,,Gimnasio,
+8,C1,Jalón polea alta supino,31.75,4,15,kg,,Gimnasio,
+8,C1,Remo sentado con polea,65,4,15,kg,,Gimnasio,
+8,C1,Curl biceps,6,4,15,kg,,Gimnasio,
+8,C1,Curl martillo,6,4,15,kg,,Gimnasio,
+9,C1,Jalón polea alta prono,33,3,15,kg,,Gimnasio,
+9,C1,Jalón polea alta prono,40,1,15,kg,,Gimnasio,
+9,C1,Jalón polea alta supino,33,3,15,kg,,Gimnasio,
+9,C1,Jalón polea alta supino,40,1,15,kg,,Gimnasio,
+9,C1,Remo sentado con polea,65,4,15,kg,,Gimnasio,
+9,C1,Curl biceps,10,4,15,kg,,Gimnasio,
+9,C1,Curl martillo,7,4,15,kg,,Gimnasio,
+10,C1,Leg press,80,4,20,kg,,Gimnasio,
+10,C1,Hack squat,40,4,15,kg,,Gimnasio,
+10,C1,Aducción,79.37,4,20,kg,,Gimnasio,
+10,C1,Leg extension,36.28,4,20,kg,,Gimnasio,
+11,C1,Press de pecho,40,4,20,kg,,Gimnasio,
+11,C1,Extensión de hombro,25,4,15,kg,,Gimnasio,
+11,C1,Extensión de tríceps en polea,13.75,1,15,kg,,Gimnasio,
+11,C1,Extensión de tríceps en polea,16.25,3,15,kg,,Gimnasio,
+11,C1,Extensión lateral,6.25,3,15,kg,,Gimnasio,
+11,C1,Extensión frontal,6.25,1,15,kg,,Gimnasio,
+12,C1,Peso muerto,22,4,15,kg,,Gimnasio,
+12,C1,Leg Curl,47.62,4,20,kg,,Gimnasio,
+12,C1,Abducción,81.64,4,20,kg,,Gimnasio,
+12,C1,Glúteo en maquina,40,1,15,kg,,Gimnasio,
+12,C1,Glúteo en maquina,42.5,2,15,kg,,Gimnasio,
+13,C1,Jalón polea alta prono,28.5,4,15,kg,,Gimnasio,
+13,C1,Jalón polea alta supino,28.5,4,15,kg,,Gimnasio,
+13,C1,Remo sentado con polea,42.5,4,15,kg,,Gimnasio,
+13,C1,Curl biceps,10,3,10,kg,,Gimnasio,
+13,C1,Curl martillo,6,3,10,kg,,Gimnasio,
+14,C1,Leg press,50,4,20,kg,,Gimnasio,
+14,C1,Sentadilla,15,1,15,kg,,Gimnasio,
+14,C1,Sentadilla,20,1,15,kg,,Gimnasio,
+14,C1,Sentadilla,25,2,8,kg,,Gimnasio,
+14,C1,Aducción,105,4,20,kg,,Gimnasio,
+14,C1,Leg extension,105,4,20,kg,,Gimnasio,
+15,C1,Press de pecho,12,4,20,kg,,Gimnasio,
+15,C1,Extensión de hombro,15,4,15,kg,,Gimnasio,
+15,C1,Extensión de tríceps en polea,11.25,4,15,kg,,Gimnasio,
+15,C1,Extensión lateral,3.75,3,15,kg,,Gimnasio,
+15,C1,Extensión frontal,3.75,3,15,kg,,Gimnasio,
+16,C1,Peso muerto,22,4,15,kg,,Gimnasio,
+16,C1,Leg Curl,65,4,20,kg,,Gimnasio,
+16,C1,Hip thrust,20,4,15,kg,,Gimnasio,
+16,C1,Abducción,105,4,20,kg,,Gimnasio,
+16,C1,Glúteo en maquina,25,3,15,kg,,Gimnasio,
+17,C1,Abducción,175,1,20,kg,,Gimnasio,
+17,C1,Abducción,190,1,15,kg,,Gimnasio,
+17,C1,Abducción,205,1,12,kg,,Gimnasio,
+17,C1,Abducción,220,1,10,kg,,Gimnasio,
+17,C1,Hack squat,20,1,20,kg,,Gimnasio,
+17,C1,Hack squat,30,1,15,kg,,Gimnasio,
+17,C1,Hack squat,40,1,12,kg,,Gimnasio,
+17,C1,Hack squat,50,1,10,kg,,Gimnasio,
+17,C1,Leg press,70,1,20,kg,,Gimnasio,
+17,C1,Leg press,80,1,15,kg,,Gimnasio,
+17,C1,Leg press,90,1,12,kg,,Gimnasio,
+17,C1,Leg press,100,1,10,kg,,Gimnasio,
+17,C1,Leg extension,105,1,20,kg,,Gimnasio,
+17,C1,Leg extension,115,1,15,kg,,Gimnasio,
+17,C1,Leg extension,130,1,12,kg,,Gimnasio,
+17,C1,Leg extension,145,1,10,kg,,Gimnasio,
+18,C1,Remo sentado con polea,28.75,1,20,kg,,Gimnasio,
+18,C1,Remo sentado con polea,31.25,1,15,kg,,Gimnasio,
+18,C1,Remo sentado con polea,33.75,1,12,kg,,Gimnasio,
+18,C1,Remo sentado con polea,36.25,1,10,kg,,Gimnasio,
+18,C1,Jalón polea alta prono,33,4,15,kg,,Gimnasio,
+18,C1,Jalón polea alta supino,33,4,15,kg,,Gimnasio,
+18,C1,Curl biceps,10,3,20,kg,,Gimnasio,
+18,C1,Curl martillo,9,3,10,kg,,Gimnasio,
+19,C1,Peso muerto,22,4,15,kg,,Gimnasio,
+19,C1,Leg Curl,105,1,20,kg,,Gimnasio,
+19,C1,Leg Curl,115,1,15,kg,,Gimnasio,
+19,C1,Leg Curl,130,1,12,kg,,Gimnasio,
+19,C1,Leg Curl,145,1,10,kg,,Gimnasio,
+19,C1,Hip thrust,20,3,15,kg,,Gimnasio,
+19,C1,Abducción,175,1,20,kg,,Gimnasio,
+19,C1,Abducción,190,1,15,kg,,Gimnasio,
+19,C1,Abducción,205,1,12,kg,,Gimnasio,
+19,C1,Abducción,220,1,10,kg,,Gimnasio,
+19,C1,Glúteo en maquina,42.5,1,15,kg,,Gimnasio,
+19,C1,Glúteo en maquina,47.5,1,12,kg,,Gimnasio,
+19,C1,Glúteo en maquina,52.5,1,10,kg,,Gimnasio,
+20,C1,Press de pecho,19,1,20,kg,,Gimnasio,
+20,C1,Press de pecho,26,1,15,kg,,Gimnasio,
+20,C1,Press de pecho,33,1,12,kg,,Gimnasio,
+20,C1,Press de pecho,40,1,10,kg,,Gimnasio,
+20,C1,Extensión de hombro,25,1,20,kg,,Gimnasio,
+20,C1,Extensión de hombro,35,1,15,kg,,Gimnasio,
+20,C1,Extensión de hombro,45,1,12,kg,,Gimnasio,
+20,C1,Extensión de hombro,50,1,10,kg,,Gimnasio,
+20,C1,Extensión de tríceps en polea,11.25,4,15,kg,,Gimnasio,
+20,C1,Extensión lateral,3.75,3,15,kg,,Gimnasio,
+20,C1,Extensión frontal,3.75,3,15,kg,,Gimnasio,

--- a/data/Progreso.csv
+++ b/data/Progreso.csv
@@ -1,4 +1,4 @@
-Dia,Id_Usuario,Ejercicio,Peso,Sets,Repeticiones,Unidad,Distancia,Tipo,Tiempo
+Dia,Id_Usuario,Ejercicio,Peso,Sets,Repeticiones,Unidad,Distancia,Tipo,Tiempo,Notas
 1,C1,Press de pecho,26,1,15,kg,,Gimnasio,
 1,C1,Press de pecho,33,2,15,kg,,Gimnasio,
 1,C1,Press de pecho,38,1,15,kg,,Gimnasio,

--- a/data/Progreso.csv
+++ b/data/Progreso.csv
@@ -1,160 +1,160 @@
-﻿Dia,Id_Usuario,Maquina,Peso,Sets,Repeticiones,Medida
-1,C1,Press de pecho,26,1,15,kg
-1,C1,Press de pecho,33,2,15,kg
-1,C1,Press de pecho,38,1,15,kg
-1,C2,Press de pecho,5,1,15,kg
-1,C2,Press de pecho,12,3,15,kg
-1,C1,Extensión de hombro,15,3,15,kg
-1,C2,Extensión de hombro,5,3,15,kg
-1,C1,Extensión de tríceps en polea,13.75,1,15,kg
-1,C1,Extensión de tríceps en polea,16.25,3,15,kg
-1,C2,Extensión de tríceps en polea,6.25,4,15,kg
-1,C1,Extensión lateral,6.25,3,10,kg
-1,C2,Extensión lateral,1.25,3,10,kg
-1,C1,Extensión frontal,3.75,3,10,kg
-1,C2,Extensión frontal,1.25,3,10,kg
-2,C1,Peso muerto,22,4,15,kg
-2,C1,Leg Curl,47.5,4,20,kg
-2,C1,Abducción,50,1,20,kg
-2,C1,Abducción,60,1,20,kg
-2,C1,Abducción,70,1,20,kg
-2,C1,Abducción,80,1,20,kg
-2,C1,Glúteo en maquina,30,1,15,kg
-2,C1,Glúteo en maquina,32.5,1,15,kg
-2,C1,Glúteo en maquina,35,1,15,kg
-2,C2,Peso muerto,10,4,15,kg
-2,C2,Leg Curl,17.5,1,20,kg
-2,C2,Leg Curl,20,3,20,kg
-2,C2,Abducción,27.5,1,15,kg
-2,C2,Abducción,30,2,15,kg
-2,C2,Abducción,35,1,15,kg
-2,C2,Glúteo en maquina,20,3,15,kg
-3,C1,Leg press,80,4,20,kg
-3,C1,Hack squat,40,4,15,kg
-3,C1,Aducción,80,4,20,kg
-3,C1,Leg extension,80,4,20,kg
-4,C1,Jalón polea alta prono,33,4,15,kg
-4,C1,Jalón polea alta supino,33,4,15,kg
-4,C1,Remo sentado con polea,65,4,15,kg
-4,C1,Curl biceps,10,4,10,kg
-4,C1,Curl martillo,7,4,10,kg
-5,C1,Abducción,80,4,20,kg
-5,C1,Glúteo en maquina,40,3,15,kg
-5,C1,Hip thrust,15,2,15,kg
-5,C1,Hip thrust,20,2,15,kg
-5,C1,Leg Curl,42.5,3,20,kg
-5,C1,Peso muerto,22,3,15,kg
-3,C2,Abducción,35,1,20,kg
-3,C2,Abducción,40,2,20,kg
-3,C2,Abducción,42.5,1,20,kg
-3,C2,Glúteo en maquina,20,1,15,kg
-3,C2,Glúteo en maquina,25,2,15,kg
-3,C2,Hip thrust,5,1,15,kg
-3,C2,Hip thrust,10,3,15,kg
-3,C2,Leg Curl,15,3,15,kg
-3,C2,Peso muerto,12,3,15,kg
-6,C1,Leg extension,80,4,20,kg
-6,C1,Leg press,80,4,20,kg
-6,C1,Aducción,80,4,20,kg
-7,C1,Press de pecho,40,4,20,kg
-7,C1,Extensión de hombro,26,4,15,kg
-7,C1,Extensión de tríceps en polea,27.5,4,15,kg
-7,C1,Extensión lateral,7.5,3,15,kg
-7,C1,Extensión frontal,4,1,15,kg
-7,C1,Extensión frontal,7.5,2,15,kg
-8,C1,Jalón polea alta prono,31.75,4,15,kg
-8,C1,Jalón polea alta supino,31.75,4,15,kg
-8,C1,Remo sentado con polea,65,4,15,kg
-8,C1,Curl biceps,6,4,15,kg
-8,C1,Curl martillo,6,4,15,kg
-9,C1,Jalón polea alta prono,33,3,15,kg
-9,C1,Jalón polea alta prono,40,1,15,kg
-9,C1,Jalón polea alta supino,33,3,15,kg
-9,C1,Jalón polea alta supino,40,1,15,kg
-9,C1,Remo sentado con polea,65,4,15,kg
-9,C1,Curl biceps,10,4,15,kg
-9,C1,Curl martillo,7,4,15,kg
-10,C1,Leg press,80,4,20,kg
-10,C1,Hack squat,40,4,15,kg
-10,C1,Aducción,79.37,4,20,kg
-10,C1,Leg extension,36.28,4,20,kg
-11,C1,Press de pecho,40,4,20,kg
-11,C1,Extensión de hombro,25,4,15,kg
-11,C1,Extensión de tríceps en polea,13.75,1,15,kg
-11,C1,Extensión de tríceps en polea,16.25,3,15,kg
-11,C1,Extensión lateral,6.25,3,15,kg
-11,C1,Extensión frontal,6.25,1,15,kg
-12,C1,Peso muerto,22,4,15,kg
-12,C1,Leg Curl,47.62,4,20,kg
-12,C1,Abducción,81.64,4,20,kg
-12,C1,Glúteo en maquina,40,1,15,kg
-12,C1,Glúteo en maquina,42.5,2,15,kg
-13,C1,Jalón polea alta prono,28.5,4,15,kg
-13,C1,Jalón polea alta supino,28.5,4,15,kg
-13,C1,Remo sentado con polea,42.5,4,15,kg
-13,C1,Curl biceps,10,3,10,kg
-13,C1,Curl martillo,6,3,10,kg
-14,C1,Leg press,50,4,20,kg
-14,C1,Sentadilla,15,1,15,kg
-14,C1,Sentadilla,20,1,15,kg
-14,C1,Sentadilla,25,2,8,kg
-14,C1,Aducción,105,4,20,lb
-14,C1,Leg extension,105,4,20,lb
-15,C1,Press de pecho,12,4,20,kg
-15,C1,Extensión de hombro,15,4,15,lb
-15,C1,Extensión de tríceps en polea,11.25,4,15,kg
-15,C1,Extensión lateral,3.75,3,15,kg
-15,C1,Extensión frontal,3.75,3,15,kg
-16,C1,Peso muerto,22,4,15,kg
-16,C1,Leg Curl,65,4,20,lb
-16,C1,Hip thrust,20,4,15,kg
-16,C1,Abducción,105,4,20,lb
-16,C1,Glúteo en maquina,25,3,15,kg
-17,C1,Abducción,175,1,20,lb
-17,C1,Abducción,190,1,15,lb
-17,C1,Abducción,205,1,12,lb
-17,C1,Abducción,220,1,10,lb
-17,C1,Hack squat,20,1,20,kg
-17,C1,Hack squat,30,1,15,kg
-17,C1,Hack squat,40,1,12,kg
-17,C1,Hack squat,50,1,10,kg
-17,C1,Leg press,70,1,20,kg
-17,C1,Leg press,80,1,15,kg
-17,C1,Leg press,90,1,12,kg
-17,C1,Leg press,100,1,10,kg
-17,C1,Leg extension,105,1,20,lb
-17,C1,Leg extension,115,1,15,lb
-17,C1,Leg extension,130,1,12,lb
-17,C1,Leg extension,145,1,10,lb
-18,C1,Remo sentado con polea,28.75,1,20,kg
-18,C1,Remo sentado con polea,31.25,1,15,kg
-18,C1,Remo sentado con polea,33.75,1,12,kg
-18,C1,Remo sentado con polea,36.25,1,10,kg
-18,C1,Jalón polea alta prono,33,4,15,kg
-18,C1,Jalón polea alta supino,33,4,15,kg
-18,C1,Curl biceps,10,3,20,kg
-18,C1,Curl martillo,9,3,10,kg
-19,C1,Peso muerto,22,4,15,kg
-19,C1,Leg Curl,105,1,20,lb
-19,C1,Leg Curl,115,1,15,lb
-19,C1,Leg Curl,130,1,12,lb
-19,C1,Leg Curl,145,1,10,lb
-19,C1,Hip thrust,20,3,15,kg
-19,C1,Abducción,175,1,20,lb
-19,C1,Abducción,190,1,15,lb
-19,C1,Abducción,205,1,12,lb
-19,C1,Abducción,220,1,10,lb
-19,C1,Glúteo en maquina,42.5,1,15,kg
-19,C1,Glúteo en maquina,47.5,1,12,kg
-19,C1,Glúteo en maquina,52.5,1,10,kg
-20,C1,Press de pecho,19,1,20,kg
-20,C1,Press de pecho,26,1,15,kg
-20,C1,Press de pecho,33,1,12,kg
-20,C1,Press de pecho,40,1,10,kg
-20,C1,Extensión de hombro,25,1,20,lb
-20,C1,Extensión de hombro,35,1,15,lb
-20,C1,Extensión de hombro,45,1,12,lb
-20,C1,Extensión de hombro,50,1,10,lb
-20,C1,Extensión de tríceps en polea,11.25,4,15,kg
-20,C1,Extensión lateral,3.75,3,15,kg
-20,C1,Extensión frontal,3.75,3,15,kg
+Dia,Id_Usuario,Ejercicio,Peso,Sets,Repeticiones
+1,C1,Press de pecho,26,1,15
+1,C1,Press de pecho,33,2,15
+1,C1,Press de pecho,38,1,15
+1,C2,Press de pecho,5,1,15
+1,C2,Press de pecho,12,3,15
+1,C1,Extensión de hombro,15,3,15
+1,C2,Extensión de hombro,5,3,15
+1,C1,Extensión de tríceps en polea,13.75,1,15
+1,C1,Extensión de tríceps en polea,16.25,3,15
+1,C2,Extensión de tríceps en polea,6.25,4,15
+1,C1,Extensión lateral,6.25,3,10
+1,C2,Extensión lateral,1.25,3,10
+1,C1,Extensión frontal,3.75,3,10
+1,C2,Extensión frontal,1.25,3,10
+2,C1,Peso muerto,22,4,15
+2,C1,Leg Curl,47.5,4,20
+2,C1,Abducción,50,1,20
+2,C1,Abducción,60,1,20
+2,C1,Abducción,70,1,20
+2,C1,Abducción,80,1,20
+2,C1,Glúteo en maquina,30,1,15
+2,C1,Glúteo en maquina,32.5,1,15
+2,C1,Glúteo en maquina,35,1,15
+2,C2,Peso muerto,10,4,15
+2,C2,Leg Curl,17.5,1,20
+2,C2,Leg Curl,20,3,20
+2,C2,Abducción,27.5,1,15
+2,C2,Abducción,30,2,15
+2,C2,Abducción,35,1,15
+2,C2,Glúteo en maquina,20,3,15
+3,C1,Leg press,80,4,20
+3,C1,Hack squat,40,4,15
+3,C1,Aducción,80,4,20
+3,C1,Leg extension,80,4,20
+4,C1,Jalón polea alta prono,33,4,15
+4,C1,Jalón polea alta supino,33,4,15
+4,C1,Remo sentado con polea,65,4,15
+4,C1,Curl biceps,10,4,10
+4,C1,Curl martillo,7,4,10
+5,C1,Abducción,80,4,20
+5,C1,Glúteo en maquina,40,3,15
+5,C1,Hip thrust,15,2,15
+5,C1,Hip thrust,20,2,15
+5,C1,Leg Curl,42.5,3,20
+5,C1,Peso muerto,22,3,15
+3,C2,Abducción,35,1,20
+3,C2,Abducción,40,2,20
+3,C2,Abducción,42.5,1,20
+3,C2,Glúteo en maquina,20,1,15
+3,C2,Glúteo en maquina,25,2,15
+3,C2,Hip thrust,5,1,15
+3,C2,Hip thrust,10,3,15
+3,C2,Leg Curl,15,3,15
+3,C2,Peso muerto,12,3,15
+6,C1,Leg extension,80,4,20
+6,C1,Leg press,80,4,20
+6,C1,Aducción,80,4,20
+7,C1,Press de pecho,40,4,20
+7,C1,Extensión de hombro,26,4,15
+7,C1,Extensión de tríceps en polea,27.5,4,15
+7,C1,Extensión lateral,7.5,3,15
+7,C1,Extensión frontal,4,1,15
+7,C1,Extensión frontal,7.5,2,15
+8,C1,Jalón polea alta prono,31.75,4,15
+8,C1,Jalón polea alta supino,31.75,4,15
+8,C1,Remo sentado con polea,65,4,15
+8,C1,Curl biceps,6,4,15
+8,C1,Curl martillo,6,4,15
+9,C1,Jalón polea alta prono,33,3,15
+9,C1,Jalón polea alta prono,40,1,15
+9,C1,Jalón polea alta supino,33,3,15
+9,C1,Jalón polea alta supino,40,1,15
+9,C1,Remo sentado con polea,65,4,15
+9,C1,Curl biceps,10,4,15
+9,C1,Curl martillo,7,4,15
+10,C1,Leg press,80,4,20
+10,C1,Hack squat,40,4,15
+10,C1,Aducción,79.37,4,20
+10,C1,Leg extension,36.28,4,20
+11,C1,Press de pecho,40,4,20
+11,C1,Extensión de hombro,25,4,15
+11,C1,Extensión de tríceps en polea,13.75,1,15
+11,C1,Extensión de tríceps en polea,16.25,3,15
+11,C1,Extensión lateral,6.25,3,15
+11,C1,Extensión frontal,6.25,1,15
+12,C1,Peso muerto,22,4,15
+12,C1,Leg Curl,47.62,4,20
+12,C1,Abducción,81.64,4,20
+12,C1,Glúteo en maquina,40,1,15
+12,C1,Glúteo en maquina,42.5,2,15
+13,C1,Jalón polea alta prono,28.5,4,15
+13,C1,Jalón polea alta supino,28.5,4,15
+13,C1,Remo sentado con polea,42.5,4,15
+13,C1,Curl biceps,10,3,10
+13,C1,Curl martillo,6,3,10
+14,C1,Leg press,50,4,20
+14,C1,Sentadilla,15,1,15
+14,C1,Sentadilla,20,1,15
+14,C1,Sentadilla,25,2,8
+14,C1,Aducción,105,4,20
+14,C1,Leg extension,105,4,20
+15,C1,Press de pecho,12,4,20
+15,C1,Extensión de hombro,15,4,15
+15,C1,Extensión de tríceps en polea,11.25,4,15
+15,C1,Extensión lateral,3.75,3,15
+15,C1,Extensión frontal,3.75,3,15
+16,C1,Peso muerto,22,4,15
+16,C1,Leg Curl,65,4,20
+16,C1,Hip thrust,20,4,15
+16,C1,Abducción,105,4,20
+16,C1,Glúteo en maquina,25,3,15
+17,C1,Abducción,175,1,20
+17,C1,Abducción,190,1,15
+17,C1,Abducción,205,1,12
+17,C1,Abducción,220,1,10
+17,C1,Hack squat,20,1,20
+17,C1,Hack squat,30,1,15
+17,C1,Hack squat,40,1,12
+17,C1,Hack squat,50,1,10
+17,C1,Leg press,70,1,20
+17,C1,Leg press,80,1,15
+17,C1,Leg press,90,1,12
+17,C1,Leg press,100,1,10
+17,C1,Leg extension,105,1,20
+17,C1,Leg extension,115,1,15
+17,C1,Leg extension,130,1,12
+17,C1,Leg extension,145,1,10
+18,C1,Remo sentado con polea,28.75,1,20
+18,C1,Remo sentado con polea,31.25,1,15
+18,C1,Remo sentado con polea,33.75,1,12
+18,C1,Remo sentado con polea,36.25,1,10
+18,C1,Jalón polea alta prono,33,4,15
+18,C1,Jalón polea alta supino,33,4,15
+18,C1,Curl biceps,10,3,20
+18,C1,Curl martillo,9,3,10
+19,C1,Peso muerto,22,4,15
+19,C1,Leg Curl,105,1,20
+19,C1,Leg Curl,115,1,15
+19,C1,Leg Curl,130,1,12
+19,C1,Leg Curl,145,1,10
+19,C1,Hip thrust,20,3,15
+19,C1,Abducción,175,1,20
+19,C1,Abducción,190,1,15
+19,C1,Abducción,205,1,12
+19,C1,Abducción,220,1,10
+19,C1,Glúteo en maquina,42.5,1,15
+19,C1,Glúteo en maquina,47.5,1,12
+19,C1,Glúteo en maquina,52.5,1,10
+20,C1,Press de pecho,19,1,20
+20,C1,Press de pecho,26,1,15
+20,C1,Press de pecho,33,1,12
+20,C1,Press de pecho,40,1,10
+20,C1,Extensión de hombro,25,1,20
+20,C1,Extensión de hombro,35,1,15
+20,C1,Extensión de hombro,45,1,12
+20,C1,Extensión de hombro,50,1,10
+20,C1,Extensión de tríceps en polea,11.25,4,15
+20,C1,Extensión lateral,3.75,3,15
+20,C1,Extensión frontal,3.75,3,15

--- a/data/Rutinas.csv
+++ b/data/Rutinas.csv
@@ -1,0 +1,1 @@
+Nombre,Ejercicio,Sets,Reps

--- a/data/Usuarios.csv
+++ b/data/Usuarios.csv
@@ -1,3 +1,3 @@
-﻿Id_Usuario,Nombre,Color
-C1,Carlos,Black
-C2,Cinthia,Light blue
+Id_Usuario,Nombre,Color,Username,Password
+C1,Carlos,Black,carlos,password1
+C2,Cinthia,Light blue,cinthia,password2

--- a/main.py
+++ b/main.py
@@ -8,14 +8,22 @@ CATALOGO_CSV = 'data/Grupo_muscular.csv'
 
 
 def load_dfs():
+    cols = ['Dia', 'Id_Usuario', 'Ejercicio', 'Peso', 'Sets',
+            'Repeticiones', 'Unidad', 'Distancia', 'Tipo', 'Tiempo']
     try:
         progreso = pd.read_csv(PROGRESO_CSV)
+        for c in cols:
+            if c not in progreso.columns:
+                progreso[c] = None
+        progreso = progreso[cols]
     except FileNotFoundError:
-        progreso = pd.DataFrame(columns=['Dia', 'Id_Usuario', 'Ejercicio', 'Peso', 'Sets', 'Repeticiones'])
+        progreso = pd.DataFrame(columns=cols)
     try:
         catalogo = pd.read_csv(CATALOGO_CSV)
+        if 'Tipo' not in catalogo.columns:
+            catalogo['Tipo'] = 'Gimnasio'
     except FileNotFoundError:
-        catalogo = pd.DataFrame(columns=['Grupo_Muscular', 'Ejercicio'])
+        catalogo = pd.DataFrame(columns=['Grupo_Muscular', 'Ejercicio', 'Tipo'])
     try:
         usuarios = pd.read_csv(USUARIOS_CSV)
     except FileNotFoundError:
@@ -91,9 +99,10 @@ with st.expander('📚 Catálogo de Ejercicios'):
     with st.form('add_exercise'):
         grupo = st.text_input('Grupo Muscular')
         ejercicio = st.text_input('Ejercicio')
+        tipo_ej = st.selectbox('Tipo', ['Gimnasio', 'Carrera'])
         submitted = st.form_submit_button('Agregar')
         if submitted and grupo and ejercicio:
-            grupo_muscular_df.loc[len(grupo_muscular_df)] = [grupo, ejercicio]
+            grupo_muscular_df.loc[len(grupo_muscular_df)] = [grupo, ejercicio, tipo_ej]
             save_df(grupo_muscular_df, CATALOGO_CSV)
             st.experimental_rerun()
     if not grupo_muscular_df.empty:
@@ -105,18 +114,53 @@ with st.expander('📚 Catálogo de Ejercicios'):
 
 # ------ Registro de entrenamiento ------
 with st.expander('📝 Registrar Entrenamiento'):
+    tipo = st.selectbox('Tipo', ['Gimnasio', 'Carrera'])
     dia = st.text_input('Día')
-    ejercicio = st.selectbox('Ejercicio', grupo_muscular_df['Ejercicio'].unique())
-    sets = st.number_input('Sets', min_value=1, max_value=10, step=1, value=4)
-    peso = st.number_input('Peso', min_value=0.0, step=0.1)
-    reps = st.number_input('Repeticiones', min_value=1, step=1, value=10)
-    if st.button('Guardar') and dia:
-        nuevo = pd.DataFrame({'Dia': [dia], 'Id_Usuario': [st.session_state['user_id']],
-                             'Ejercicio': [ejercicio], 'Peso': [peso], 'Sets': [sets],
-                             'Repeticiones': [reps]})
-        progreso_df = pd.concat([progreso_df, nuevo], ignore_index=True)
-        save_df(progreso_df, PROGRESO_CSV)
-        st.success('Entrenamiento guardado')
+    if tipo == 'Gimnasio':
+        ejercicios = grupo_muscular_df[grupo_muscular_df['Tipo'] == 'Gimnasio']['Ejercicio']
+        ejercicio = st.selectbox('Ejercicio', ejercicios.unique())
+        sets = st.number_input('Sets', min_value=1, max_value=10, step=1, value=4)
+        unidad = st.selectbox('Unidad', ['kg', 'lb'])
+        peso = st.number_input('Peso', min_value=0.0, step=0.1)
+        reps = st.number_input('Repeticiones', min_value=1, step=1, value=10)
+        if st.button('Guardar') and dia:
+            peso_kg = peso * 0.453592 if unidad == 'lb' else peso
+            nuevo = pd.DataFrame({
+                'Dia': [dia],
+                'Id_Usuario': [st.session_state['user_id']],
+                'Ejercicio': [ejercicio],
+                'Peso': [peso_kg],
+                'Sets': [sets],
+                'Repeticiones': [reps],
+                'Unidad': [unidad],
+                'Distancia': [None],
+                'Tipo': ['Gimnasio'],
+                'Tiempo': [None]
+            })
+            progreso_df = pd.concat([progreso_df, nuevo], ignore_index=True)
+            save_df(progreso_df, PROGRESO_CSV)
+            st.success('Entrenamiento guardado')
+    else:
+        ejercicios = grupo_muscular_df[grupo_muscular_df['Tipo'] == 'Carrera']['Ejercicio']
+        ejercicio = st.selectbox('Ejercicio', ejercicios.unique())
+        distancia = st.number_input('Distancia (km)', min_value=0.0, step=0.1)
+        tiempo = st.number_input('Tiempo (min)', min_value=0.0, step=1.0)
+        if st.button('Guardar') and dia:
+            nuevo = pd.DataFrame({
+                'Dia': [dia],
+                'Id_Usuario': [st.session_state['user_id']],
+                'Ejercicio': [ejercicio],
+                'Peso': [0],
+                'Sets': [1],
+                'Repeticiones': [1],
+                'Unidad': ['km'],
+                'Distancia': [distancia],
+                'Tipo': ['Carrera'],
+                'Tiempo': [tiempo]
+            })
+            progreso_df = pd.concat([progreso_df, nuevo], ignore_index=True)
+            save_df(progreso_df, PROGRESO_CSV)
+            st.success('Entrenamiento guardado')
 
 # ------ Panel de progreso ------
 with st.expander('📊 Progreso'):
@@ -124,16 +168,43 @@ with st.expander('📊 Progreso'):
     if usuario_datos.empty:
         st.info('Aún no hay datos registrados')
     else:
-        usuario_datos['Volumen'] = usuario_datos['Peso'] * usuario_datos['Repeticiones'] * usuario_datos['Sets']
-        total_volumen = usuario_datos['Volumen'].sum()
+        gimnasio = usuario_datos[usuario_datos['Tipo'] == 'Gimnasio'].copy()
+        gimnasio['Peso_kg'] = gimnasio.apply(lambda r: r['Peso'] if r['Unidad'] != 'lb' else r['Peso'] * 0.453592, axis=1)
+        gimnasio['Volumen'] = gimnasio['Peso_kg'] * gimnasio['Repeticiones'] * gimnasio['Sets']
+        total_volumen = gimnasio['Volumen'].sum()
         dias = usuario_datos['Dia'].nunique()
-        st.metric('Volumen total', f"{total_volumen:.2f}")
+        st.metric('Volumen total', f"{total_volumen:.2f} kg")
         st.metric('Días registrados', dias)
-        pr = usuario_datos.groupby('Ejercicio')['Peso'].max().reset_index(name='PR')
+
+        pr = gimnasio.groupby('Ejercicio')['Peso_kg'].max().reset_index(name='PR (kg)')
         st.subheader('Récords personales')
         st.dataframe(pr)
-        grafica = alt.Chart(usuario_datos).mark_line().encode(
-            x='Dia:T', y='Peso', color='Ejercicio'
+
+        st.subheader('Peso promedio por ejercicio')
+        promedio = gimnasio.groupby('Ejercicio')['Peso_kg'].mean().reset_index(name='Promedio (kg)')
+        st.dataframe(promedio)
+
+        grafica = alt.Chart(gimnasio).mark_line().encode(
+            x='Dia:T', y='Peso_kg', color='Ejercicio'
         )
         st.altair_chart(grafica, use_container_width=True)
+
+        carreras = usuario_datos[usuario_datos['Tipo'] == 'Carrera']
+        if not carreras.empty:
+            total_km = carreras['Distancia'].sum()
+            st.metric('Kilómetros acumulados', f"{total_km:.2f} km")
+            graf_km = alt.Chart(carreras).mark_line().encode(
+                x='Dia:T', y='Distancia', color='Ejercicio'
+            )
+            st.altair_chart(graf_km, use_container_width=True)
+
+        st.subheader('Comparativa con otros usuarios')
+        ejercicio_comp = st.selectbox('Ejercicio', progreso_df['Ejercicio'].unique())
+        pr_usuarios = progreso_df[progreso_df['Tipo'] == 'Gimnasio']
+        pr_usuarios['Peso_kg'] = pr_usuarios.apply(lambda r: r['Peso'] if r['Unidad'] != 'lb' else r['Peso'] * 0.453592, axis=1)
+        comp = pr_usuarios[pr_usuarios['Ejercicio'] == ejercicio_comp]
+        comp = comp.groupby('Id_Usuario')['Peso_kg'].max().reset_index()
+        comp = comp.merge(usuario_df[['Id_Usuario', 'Nombre']], on='Id_Usuario')
+        graf_comp = alt.Chart(comp).mark_bar().encode(x='Nombre', y='Peso_kg')
+        st.altair_chart(graf_comp, use_container_width=True)
 

--- a/main.py
+++ b/main.py
@@ -13,8 +13,11 @@ st.set_page_config(
 st.markdown(
     """
     <style>
-        body {font-family: 'Segoe UI', sans-serif;}
+        body {font-family: 'Segoe UI', sans-serif; background-color: var(--backgr\
+ound-color);} 
         .block-container {padding-top: 2rem;}
+        [data-testid=stMetric] {background:#222;border-radius:4px;padding:0.5em;\
+ color:#fff;}
     </style>
     """,
     unsafe_allow_html=True,
@@ -197,188 +200,111 @@ with tabs[0]:
 
 with tabs[1]:
     st.header('📊 Progreso')
-    usuario_datos = progreso_df[progreso_df['Id_Usuario'] == st.session_state['user_id']]
-    if usuario_datos.empty:
+    data_user = progreso_df[progreso_df['Id_Usuario'] == st.session_state['user_id']].copy()
+    if data_user.empty:
         st.info('Aún no hay datos registrados')
     else:
-        gimnasio = usuario_datos[usuario_datos['Tipo'] == 'Gimnasio'].copy()
-        gimnasio['Peso_kg'] = gimnasio.apply(
-            lambda r: r['Peso'] if r['Unidad'] != 'lb' else r['Peso'] * 0.453592,
-            axis=1,
-        )
-        gimnasio['Fecha'] = pd.to_datetime(gimnasio['Dia'], errors='coerce')
-        min_d, max_d = gimnasio['Fecha'].min(), gimnasio['Fecha'].max()
-        rango = st.date_input('Rango de fechas', [min_d, max_d])
-        if len(rango) == 2:
-            start, end = pd.to_datetime(rango[0]), pd.to_datetime(rango[1])
-            gimnasio = gimnasio[(gimnasio['Fecha'] >= start) & (gimnasio['Fecha'] <= end)]
+        data_user['Fecha'] = pd.to_datetime(data_user['Dia'], errors='coerce')
+        rango_opt = st.selectbox('Rango', ['Hoy', '7 días', '30 días', 'Personalizado'])
+        hoy = pd.to_datetime(date.today())
+        if rango_opt == 'Hoy':
+            inicio, fin = hoy, hoy
+        elif rango_opt == '7 días':
+            inicio, fin = hoy - pd.Timedelta(days=6), hoy
+        elif rango_opt == '30 días':
+            inicio, fin = hoy - pd.Timedelta(days=29), hoy
+        else:
+            r = st.date_input('Selecciona rango', [data_user['Fecha'].min(), data_user['Fecha'].max()])
+            inicio, fin = pd.to_datetime(r[0]), pd.to_datetime(r[1]) if len(r) == 2 else (data_user['Fecha'].min(), data_user['Fecha'].max())
+        periodo = (fin - inicio).days + 1
+        datos_periodo = data_user[(data_user['Fecha'] >= inicio) & (data_user['Fecha'] <= fin)]
+        prev = data_user[(data_user['Fecha'] >= inicio - pd.Timedelta(days=periodo)) & (data_user['Fecha'] < inicio)]
 
-        ejercicios_disp = ['Todos'] + sorted(gimnasio['Ejercicio'].unique())
-        ejercicio_sel = st.selectbox('Filtrar por ejercicio', ejercicios_disp)
-        datos = gimnasio if ejercicio_sel == 'Todos' else gimnasio[gimnasio['Ejercicio'] == ejercicio_sel]
-        gimnasio['Volumen'] = gimnasio['Peso_kg'] * gimnasio['Repeticiones'] * gimnasio['Sets']
-        total_volumen = gimnasio['Volumen'].sum()
-        dias = usuario_datos['Dia'].nunique()
-        semanas = gimnasio['Fecha'].dt.to_period('W').nunique()
-        consistencia = dias / semanas if semanas else 0
-        colm1, colm2, colm3 = st.columns(3)
-        colm1.metric('Volumen total', f"{total_volumen:.2f} kg")
-        colm2.metric('Días registrados', dias)
-        colm3.metric('Consistencia (d/sem)', f"{consistencia:.1f}")
+        c1, c2 = st.columns(2)
+        show_gym = c1.checkbox('Gimnasio', True)
+        show_run = c2.checkbox('Carrera', True)
+        datos_sel = datos_periodo[(datos_periodo['Tipo'] == 'Gimnasio') & show_gym | (datos_periodo['Tipo'] == 'Carrera') & show_run]
 
-        gimnasio['1RM'] = gimnasio['Peso_kg'] * (1 + gimnasio['Repeticiones'] / 30)
-        max_1rm = gimnasio.groupby('Ejercicio')['1RM'].max().reset_index(name='Proyección 1RM')
-        st.subheader('Proyección de 1RM por ejercicio')
-        st.dataframe(max_1rm)
+        gym = datos_sel[datos_sel['Tipo'] == 'Gimnasio'].copy()
+        gym['Peso_kg'] = gym.apply(lambda r: r['Peso'] if r['Unidad'] != 'lb' else r['Peso'] * 0.453592, axis=1)
+        gym['Volumen'] = gym['Peso_kg'] * gym['Repeticiones'] * gym['Sets']
+        run = datos_sel[datos_sel['Tipo'] == 'Carrera']
 
-        pr = gimnasio.groupby('Ejercicio')['Peso_kg'].max().reset_index(name='PR (kg)')
-        st.subheader('Récords personales')
-        st.dataframe(pr)
-        pr_chart = (
-            alt.Chart(pr)
-            .mark_bar()
-            .encode(x='Ejercicio', y='PR (kg)', tooltip=['PR (kg)'])
-            .interactive()
-        )
-        st.altair_chart(pr_chart, use_container_width=True)
+        prev_gym = prev[prev['Tipo'] == 'Gimnasio'].copy()
+        prev_gym['Peso_kg'] = prev_gym.apply(lambda r: r['Peso'] if r['Unidad'] != 'lb' else r['Peso'] * 0.453592, axis=1)
+        prev_gym['Volumen'] = prev_gym['Peso_kg'] * prev_gym['Repeticiones'] * prev_gym['Sets']
+        prev_run = prev[prev['Tipo'] == 'Carrera']
 
-        st.subheader('Peso promedio por ejercicio')
-        promedio = gimnasio.groupby('Ejercicio')['Peso_kg'].mean().reset_index(name='Promedio (kg)')
-        st.dataframe(promedio)
-        prom_chart = (
-            alt.Chart(promedio)
-            .mark_bar()
-            .encode(x='Ejercicio', y='Promedio (kg)', tooltip=['Promedio (kg)'])
-            .interactive()
-        )
-        st.altair_chart(prom_chart, use_container_width=True)
+        total_vol = gym['Volumen'].sum()
+        prev_vol = prev_gym['Volumen'].sum()
+        delta_vol = total_vol - prev_vol
 
-        grafica = (
-            alt.Chart(datos)
-            .mark_line(point=True)
-            .encode(
-                x='Dia:T',
-                y='Peso_kg',
-                color='Ejercicio',
-                tooltip=['Dia', 'Ejercicio', 'Peso_kg']
-            )
-            .interactive()
-        )
-        st.altair_chart(grafica, use_container_width=True)
+        total_km = run['Distancia'].sum()
+        prev_km = prev_run['Distancia'].sum()
+        delta_km = total_km - prev_km
 
-        volumen_ej = gimnasio.groupby('Ejercicio')['Volumen'].sum().reset_index()
-        st.subheader('Volumen total por ejercicio')
-        graf_vol = (
-            alt.Chart(volumen_ej)
-            .mark_bar()
-            .encode(x='Ejercicio', y='Volumen', tooltip=['Volumen'])
-            .interactive()
-        )
-        st.altair_chart(graf_vol, use_container_width=True)
+        sesiones = datos_sel['Fecha'].nunique()
 
-        join = gimnasio.merge(
-            grupo_muscular_df[['Ejercicio', 'Grupo_Muscular']],
-            on='Ejercicio',
-            how='left',
-        )
-        grupo_vol = join.groupby('Grupo_Muscular')['Volumen'].sum().reset_index()
-        st.subheader('Volumen por grupo muscular')
-        graf_grupo = (
-            alt.Chart(grupo_vol)
-            .mark_bar()
-            .encode(x='Grupo_Muscular', y='Volumen', tooltip=['Volumen'])
-            .interactive()
-        )
-        st.altair_chart(graf_grupo, use_container_width=True)
+        gym['1RM'] = gym['Peso_kg'] * (1 + gym['Repeticiones'] / 30)
+        if not gym.empty:
+            pr_row = gym.loc[gym['1RM'].idxmax()]
+            ultimo_pr = f"{pr_row['Ejercicio']} {pr_row['1RM']:.1f} kg"
+        elif not run.empty:
+            ultimo_pr = f"Distancia máx {run['Distancia'].max():.1f} km"
+        else:
+            ultimo_pr = '-'
 
-        gimnasio['Semana'] = gimnasio['Fecha'].dt.to_period('W').astype(str)
-        semanal = gimnasio.groupby('Semana')['Volumen'].sum().reset_index()
-        st.subheader('Volumen semanal')
-        graf_sem = (
-            alt.Chart(semanal)
-            .mark_line(point=True)
-            .encode(x='Semana', y='Volumen', tooltip=['Semana', 'Volumen'])
-            .interactive()
-        )
-        st.altair_chart(graf_sem, use_container_width=True)
+        m1, m2, m3, m4 = st.columns(4)
+        m1.metric('Carga total', f"{total_vol:.1f} kg", f"{delta_vol:+.1f}")
+        m2.metric('Distancia', f"{total_km:.1f} km", f"{delta_km:+.1f}")
+        m3.metric('Sesiones', sesiones)
+        m4.metric('Último PR', ultimo_pr)
 
-        avg_sem = gimnasio.groupby(['Semana', 'Ejercicio'])['Peso_kg'].mean().reset_index()
-        st.subheader('Peso promedio semanal')
-        graf_avg = (
-            alt.Chart(avg_sem)
-            .mark_line(point=True)
-            .encode(
-                x='Semana',
-                y='Peso_kg',
-                color='Ejercicio',
-                tooltip=['Semana', 'Ejercicio', 'Peso_kg'],
-            )
-            .interactive()
-        )
-        st.altair_chart(graf_avg, use_container_width=True)
-
-        gimnasio['Mes'] = gimnasio['Fecha'].dt.to_period('M').astype(str)
-        mensual = gimnasio.groupby('Mes')['Volumen'].sum().reset_index()
-        st.subheader('Volumen mensual')
-        graf_mens = (
-            alt.Chart(mensual)
-            .mark_bar()
-            .encode(x='Mes', y='Volumen', tooltip=['Volumen'])
-            .interactive()
-        )
-        st.altair_chart(graf_mens, use_container_width=True)
-
-        carreras = usuario_datos[usuario_datos['Tipo'] == 'Carrera']
-        if not carreras.empty:
-            total_km = carreras['Distancia'].sum()
-            st.metric('Kilómetros acumulados', f"{total_km:.2f} km")
-            graf_km = (
-                alt.Chart(carreras)
-                .mark_line(point=True)
-                .encode(
-                    x='Dia:T',
-                    y='Distancia',
-                    color='Ejercicio',
-                    tooltip=['Dia', 'Distancia', 'Ejercicio']
+        # --- Gráficas Gimnasio ---
+        if show_gym and not gym.empty:
+            claves = ['Press de pecho', 'Sentadilla', 'Peso muerto']
+            datos_clave = gym[gym['Ejercicio'].isin(claves)]
+            if not datos_clave.empty:
+                max_chart = (
+                    alt.Chart(datos_clave)
+                    .mark_line(point=True)
+                    .encode(x='Fecha:T', y='Peso_kg', color='Ejercicio', tooltip=['Fecha', 'Peso_kg'])
+                    .interactive()
                 )
-                .interactive()
-            )
-            st.altair_chart(graf_km, use_container_width=True)
+                st.altair_chart(max_chart, use_container_width=True)
 
-            carreras['Fecha'] = pd.to_datetime(carreras['Dia'], errors='coerce')
-            carreras['Semana'] = carreras['Fecha'].dt.to_period('W').astype(str)
-            run_sem = carreras.groupby('Semana')['Distancia'].sum().reset_index()
-            st.subheader('Distancia semanal')
-            graf_run_sem = (
-                alt.Chart(run_sem)
+            join = gym.merge(grupo_muscular_df[['Ejercicio', 'Grupo_Muscular']], on='Ejercicio', how='left')
+            join['Semana'] = join['Fecha'].dt.to_period('W').astype(str)
+            grupo_vol = join.groupby(['Semana', 'Grupo_Muscular'])['Volumen'].sum().reset_index()
+            stack = alt.Chart(grupo_vol).mark_bar().encode(x='Semana', y='Volumen', color='Grupo_Muscular')
+            st.altair_chart(stack, use_container_width=True)
+
+        # --- Gráficas Running ---
+        if show_run and not run.empty:
+            line_dist = (
+                alt.Chart(run)
                 .mark_line(point=True)
-                .encode(x='Semana', y='Distancia', tooltip=['Semana', 'Distancia'])
+                .encode(x='Fecha:T', y='Distancia', tooltip=['Fecha', 'Distancia'])
                 .interactive()
             )
-            st.altair_chart(graf_run_sem, use_container_width=True)
+            st.altair_chart(line_dist, use_container_width=True)
 
-        st.subheader('Comparativa con otros usuarios')
-        ejercicio_comp = st.selectbox('Ejercicio', progreso_df['Ejercicio'].unique())
-        pr_usuarios = progreso_df[progreso_df['Tipo'] == 'Gimnasio']
-        pr_usuarios['Peso_kg'] = pr_usuarios.apply(lambda r: r['Peso'] if r['Unidad'] != 'lb' else r['Peso'] * 0.453592, axis=1)
-        comp = pr_usuarios[pr_usuarios['Ejercicio'] == ejercicio_comp]
-        comp = comp.groupby('Id_Usuario')['Peso_kg'].max().reset_index()
-        comp = comp.merge(usuario_df[['Id_Usuario', 'Nombre']], on='Id_Usuario')
-        graf_comp = (
-            alt.Chart(comp)
-            .mark_bar()
-            .encode(x='Nombre', y='Peso_kg', tooltip=['Nombre', 'Peso_kg'])
-            .interactive()
-        )
-        st.altair_chart(graf_comp, use_container_width=True)
+            run = run[run['Distancia'] > 0]
+            if not run.empty:
+                run['ritmo'] = run['Tiempo'] / run['Distancia']
+                area_pace = (
+                    alt.Chart(run)
+                    .mark_area(opacity=0.3)
+                    .encode(x='Fecha:T', y='ritmo', tooltip=['Fecha', 'ritmo'])
+                    .interactive()
+                )
+                st.altair_chart(area_pace, use_container_width=True)
 
-        with st.expander('🚧 En progreso'):
-            st.markdown(
-                '- Seguimiento de entrenamientos personalizados\n'
-                '- Módulo de running con GPS\n'
-                '- Notificaciones y recordatorios\n'
-                '- Sincronización con plataformas de salud'
-            )
+        # --- Últimas sesiones ---
+        st.subheader('Últimas sesiones')
+        ultimas = datos_sel.sort_values('Fecha', ascending=False).head(10)
+        st.dataframe(ultimas[['Dia', 'Ejercicio', 'Peso', 'Distancia', 'Tipo']])
+
 
 with tabs[2]:
     st.header('📚 Catálogo de Ejercicios')

--- a/main.py
+++ b/main.py
@@ -9,6 +9,17 @@ st.set_page_config(
     layout="centered",
 )
 
+# Simple styling for better UX
+st.markdown(
+    """
+    <style>
+        body {font-family: 'Segoe UI', sans-serif;}
+        .block-container {padding-top: 2rem;}
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
+
 USUARIOS_CSV = 'data/Usuarios.csv'
 PROGRESO_CSV = 'data/Progreso.csv'
 CATALOGO_CSV = 'data/Grupo_muscular.csv'
@@ -51,37 +62,37 @@ if 'authenticated' not in st.session_state:
     st.session_state['user_id'] = None
 
 
-def login_form():
-    st.header('Iniciar sesión')
-    user = st.text_input('Usuario')
-    pwd = st.text_input('Contraseña', type='password')
-    if st.button('Ingresar'):
-        row = usuario_df[(usuario_df['Username'] == user) & (usuario_df['Password'] == pwd)]
-        if not row.empty:
-            st.session_state['authenticated'] = True
-            st.session_state['user_id'] = row.iloc[0]['Id_Usuario']
-            try:
-                st.experimental_rerun()
-            except Exception:
-                pass
-        else:
-            st.error('Credenciales inválidas')
+def auth_tabs():
+    tabs = st.tabs(['Iniciar sesión', 'Registro'])
 
+    with tabs[0]:
+        user = st.text_input('Usuario')
+        pwd = st.text_input('Contraseña', type='password')
+        if st.button('Ingresar'):
+            row = usuario_df[(usuario_df['Username'] == user) & (usuario_df['Password'] == pwd)]
+            if not row.empty:
+                st.session_state['authenticated'] = True
+                st.session_state['user_id'] = row.iloc[0]['Id_Usuario']
+                try:
+                    st.experimental_rerun()
+                except Exception:
+                    pass
+            else:
+                st.error('Credenciales inválidas')
 
-def register_form():
-    st.header('Registro')
-    name = st.text_input('Nombre para mostrar')
-    user = st.text_input('Usuario', key='reg_user')
-    pwd = st.text_input('Contraseña', type='password', key='reg_pwd')
-    if st.button('Registrar'):
-        if user in usuario_df['Username'].values:
-            st.error('El usuario ya existe')
-        else:
-            new_id = f'U{len(usuario_df) + 1}'
-            new_row = {'Id_Usuario': new_id, 'Nombre': name, 'Color': 'gray', 'Username': user, 'Password': pwd}
-            usuario_df.loc[len(usuario_df)] = new_row
-            save_df(usuario_df, USUARIOS_CSV)
-            st.success('Usuario registrado, ahora puede iniciar sesión')
+    with tabs[1]:
+        name = st.text_input('Nombre para mostrar')
+        user = st.text_input('Usuario', key='reg_user')
+        pwd = st.text_input('Contraseña', type='password', key='reg_pwd')
+        if st.button('Registrar'):
+            if user in usuario_df['Username'].values:
+                st.error('El usuario ya existe')
+            else:
+                new_id = f'U{len(usuario_df) + 1}'
+                new_row = {'Id_Usuario': new_id, 'Nombre': name, 'Color': 'gray', 'Username': user, 'Password': pwd}
+                usuario_df.loc[len(usuario_df)] = new_row
+                save_df(usuario_df, USUARIOS_CSV)
+                st.success('Usuario registrado')
 
 
 def logout():
@@ -94,9 +105,7 @@ def logout():
 
 
 if not st.session_state['authenticated']:
-    login_form()
-    st.divider()
-    register_form()
+    auth_tabs()
     st.stop()
 
 usuario_actual = usuario_df[usuario_df['Id_Usuario'] == st.session_state['user_id']].iloc[0]
@@ -125,10 +134,14 @@ with tabs[0]:
     if tipo == 'Gimnasio':
         ejercicios = grupo_muscular_df[grupo_muscular_df['Tipo'] == 'Gimnasio']['Ejercicio']
         ejercicio = st.selectbox('Ejercicio', ejercicios.unique())
-        sets = st.number_input('Sets', min_value=1, max_value=10, step=1, value=4)
-        unidad = st.selectbox('Unidad', ['kg', 'lb'])
-        peso = st.number_input('Peso', min_value=0.0, step=0.1)
-        reps = st.number_input('Repeticiones', min_value=1, step=1, value=10)
+        c1, c2, c3 = st.columns(3)
+        with c1:
+            sets = st.number_input('Sets', min_value=1, max_value=10, step=1, value=4)
+        with c2:
+            unidad = st.selectbox('Unidad', ['kg', 'lb'])
+            peso = st.number_input('Peso', min_value=0.0, step=0.1)
+        with c3:
+            reps = st.number_input('Repeticiones', min_value=1, step=1, value=10)
         if st.button('Guardar') and dia:
             peso_kg = peso * 0.453592 if unidad == 'lb' else peso
             nuevo = pd.DataFrame({
@@ -149,8 +162,11 @@ with tabs[0]:
     else:
         ejercicios = grupo_muscular_df[grupo_muscular_df['Tipo'] == 'Carrera']['Ejercicio']
         ejercicio = st.selectbox('Ejercicio', ejercicios.unique())
-        distancia = st.number_input('Distancia (km)', min_value=0.0, step=0.1)
-        tiempo = st.number_input('Tiempo (min)', min_value=0.0, step=1.0)
+        col1, col2 = st.columns(2)
+        with col1:
+            distancia = st.number_input('Distancia (km)', min_value=0.0, step=0.1)
+        with col2:
+            tiempo = st.number_input('Tiempo (min)', min_value=0.0, step=1.0)
         ruta = st.file_uploader('Ruta GPX/CSV (opcional)', type=['gpx', 'csv'])
         if st.button('Guardar') and dia:
             nuevo = pd.DataFrame({
@@ -190,8 +206,9 @@ with tabs[1]:
         gimnasio['Volumen'] = gimnasio['Peso_kg'] * gimnasio['Repeticiones'] * gimnasio['Sets']
         total_volumen = gimnasio['Volumen'].sum()
         dias = usuario_datos['Dia'].nunique()
-        st.metric('Volumen total', f"{total_volumen:.2f} kg")
-        st.metric('Días registrados', dias)
+        colm1, colm2 = st.columns(2)
+        colm1.metric('Volumen total', f"{total_volumen:.2f} kg")
+        colm2.metric('Días registrados', dias)
 
         gimnasio['1RM'] = gimnasio['Peso_kg'] * (1 + gimnasio['Repeticiones'] / 30)
         max_1rm = gimnasio.groupby('Ejercicio')['1RM'].max().reset_index(name='Proyección 1RM')
@@ -206,15 +223,26 @@ with tabs[1]:
         promedio = gimnasio.groupby('Ejercicio')['Peso_kg'].mean().reset_index(name='Promedio (kg)')
         st.dataframe(promedio)
 
-        grafica = alt.Chart(datos).mark_line().encode(
-            x='Dia:T', y='Peso_kg', color='Ejercicio'
+        grafica = (
+            alt.Chart(datos)
+            .mark_line(point=True)
+            .encode(
+                x='Dia:T',
+                y='Peso_kg',
+                color='Ejercicio',
+                tooltip=['Dia', 'Ejercicio', 'Peso_kg']
+            )
+            .interactive()
         )
         st.altair_chart(grafica, use_container_width=True)
 
         volumen_ej = gimnasio.groupby('Ejercicio')['Volumen'].sum().reset_index()
         st.subheader('Volumen total por ejercicio')
-        graf_vol = alt.Chart(volumen_ej).mark_bar().encode(
-            x='Ejercicio', y='Volumen'
+        graf_vol = (
+            alt.Chart(volumen_ej)
+            .mark_bar()
+            .encode(x='Ejercicio', y='Volumen', tooltip=['Volumen'])
+            .interactive()
         )
         st.altair_chart(graf_vol, use_container_width=True)
 
@@ -222,16 +250,22 @@ with tabs[1]:
         gimnasio['Semana'] = gimnasio['Fecha'].dt.to_period('W').astype(str)
         semanal = gimnasio.groupby('Semana')['Volumen'].sum().reset_index()
         st.subheader('Volumen semanal')
-        graf_sem = alt.Chart(semanal).mark_line(point=True).encode(
-            x='Semana', y='Volumen'
+        graf_sem = (
+            alt.Chart(semanal)
+            .mark_line(point=True)
+            .encode(x='Semana', y='Volumen', tooltip=['Semana', 'Volumen'])
+            .interactive()
         )
         st.altair_chart(graf_sem, use_container_width=True)
 
         gimnasio['Mes'] = gimnasio['Fecha'].dt.to_period('M').astype(str)
         mensual = gimnasio.groupby('Mes')['Volumen'].sum().reset_index()
         st.subheader('Volumen mensual')
-        graf_mens = alt.Chart(mensual).mark_bar().encode(
-            x='Mes', y='Volumen'
+        graf_mens = (
+            alt.Chart(mensual)
+            .mark_bar()
+            .encode(x='Mes', y='Volumen', tooltip=['Volumen'])
+            .interactive()
         )
         st.altair_chart(graf_mens, use_container_width=True)
 
@@ -239,8 +273,16 @@ with tabs[1]:
         if not carreras.empty:
             total_km = carreras['Distancia'].sum()
             st.metric('Kilómetros acumulados', f"{total_km:.2f} km")
-            graf_km = alt.Chart(carreras).mark_line().encode(
-                x='Dia:T', y='Distancia', color='Ejercicio'
+            graf_km = (
+                alt.Chart(carreras)
+                .mark_line(point=True)
+                .encode(
+                    x='Dia:T',
+                    y='Distancia',
+                    color='Ejercicio',
+                    tooltip=['Dia', 'Distancia', 'Ejercicio']
+                )
+                .interactive()
             )
             st.altair_chart(graf_km, use_container_width=True)
 
@@ -248,8 +290,11 @@ with tabs[1]:
             carreras['Semana'] = carreras['Fecha'].dt.to_period('W').astype(str)
             run_sem = carreras.groupby('Semana')['Distancia'].sum().reset_index()
             st.subheader('Distancia semanal')
-            graf_run_sem = alt.Chart(run_sem).mark_line(point=True).encode(
-                x='Semana', y='Distancia'
+            graf_run_sem = (
+                alt.Chart(run_sem)
+                .mark_line(point=True)
+                .encode(x='Semana', y='Distancia', tooltip=['Semana', 'Distancia'])
+                .interactive()
             )
             st.altair_chart(graf_run_sem, use_container_width=True)
 
@@ -260,7 +305,12 @@ with tabs[1]:
         comp = pr_usuarios[pr_usuarios['Ejercicio'] == ejercicio_comp]
         comp = comp.groupby('Id_Usuario')['Peso_kg'].max().reset_index()
         comp = comp.merge(usuario_df[['Id_Usuario', 'Nombre']], on='Id_Usuario')
-        graf_comp = alt.Chart(comp).mark_bar().encode(x='Nombre', y='Peso_kg')
+        graf_comp = (
+            alt.Chart(comp)
+            .mark_bar()
+            .encode(x='Nombre', y='Peso_kg', tooltip=['Nombre', 'Peso_kg'])
+            .interactive()
+        )
         st.altair_chart(graf_comp, use_container_width=True)
 
         with st.expander('🚧 En progreso'):

--- a/main.py
+++ b/main.py
@@ -269,11 +269,14 @@ with tabs[1]:
         else:
             ultimo_pr = '-'
 
-        m1, m2, m3, m4 = st.columns(4)
+        promedio_semana = sesiones / periodo * 7 if periodo else 0
+
+        m1, m2, m3, m4, m5 = st.columns(5)
         m1.metric('Carga total', f"{total_vol:.1f} kg", f"{delta_vol:+.1f}")
         m2.metric('Distancia', f"{total_km:.1f} km", f"{delta_km:+.1f}")
         m3.metric('Sesiones', sesiones)
         m4.metric('Último PR', ultimo_pr)
+        m5.metric('Consistencia', f"{promedio_semana:.1f}/sem")
 
         # --- Gráficas Gimnasio ---
         if show_gym and not gym.empty:

--- a/main.py
+++ b/main.py
@@ -205,6 +205,13 @@ with tabs[1]:
         st.info('Aún no hay datos registrados')
     else:
         data_user['Fecha'] = pd.to_datetime(data_user['Dia'], errors='coerce')
+        mask1970 = data_user['Fecha'].dt.year == 1970
+        if mask1970.any():
+            max_day = pd.to_numeric(data_user.loc[mask1970, 'Dia'], errors='coerce').max()
+            base = pd.to_datetime(date.today()) - pd.Timedelta(days=int(max_day) - 1)
+            data_user.loc[mask1970, 'Fecha'] = pd.to_numeric(data_user.loc[mask1970, 'Dia'], errors='coerce').apply(
+                lambda d: base + pd.Timedelta(days=int(d) - 1)
+            )
         rango_opt = st.selectbox('Rango', ['Hoy', '7 días', '30 días', 'Personalizado'])
         hoy = pd.to_datetime(date.today())
         if rango_opt == 'Hoy':

--- a/main.py
+++ b/main.py
@@ -129,7 +129,7 @@ tabs = st.tabs(['Registro', 'Progreso', 'Catálogo', 'Sincronización'])
 with tabs[0]:
     st.header('📝 Registrar Entrenamiento')
     tipo = st.selectbox('Tipo', ['Gimnasio', 'Carrera'])
-    dia = st.text_input('Día')
+    dia = st.date_input('Día', date.today())
     nota = st.text_area('Notas', key='nota')
     if tipo == 'Gimnasio':
         ejercicios = grupo_muscular_df[grupo_muscular_df['Tipo'] == 'Gimnasio']['Ejercicio']
@@ -143,9 +143,10 @@ with tabs[0]:
         with c3:
             reps = st.number_input('Repeticiones', min_value=1, step=1, value=10)
         if st.button('Guardar') and dia:
+            dia_str = dia.strftime('%Y-%m-%d') if isinstance(dia, date) else str(dia)
             peso_kg = peso * 0.453592 if unidad == 'lb' else peso
             nuevo = pd.DataFrame({
-                'Dia': [dia],
+                'Dia': [dia_str],
                 'Id_Usuario': [st.session_state['user_id']],
                 'Ejercicio': [ejercicio],
                 'Peso': [peso_kg],
@@ -169,8 +170,9 @@ with tabs[0]:
             tiempo = st.number_input('Tiempo (min)', min_value=0.0, step=1.0)
         ruta = st.file_uploader('Ruta GPX/CSV (opcional)', type=['gpx', 'csv'])
         if st.button('Guardar') and dia:
+            dia_str = dia.strftime('%Y-%m-%d') if isinstance(dia, date) else str(dia)
             nuevo = pd.DataFrame({
-                'Dia': [dia],
+                'Dia': [dia_str],
                 'Id_Usuario': [st.session_state['user_id']],
                 'Ejercicio': [ejercicio],
                 'Peso': [0],
@@ -206,9 +208,13 @@ with tabs[1]:
         gimnasio['Volumen'] = gimnasio['Peso_kg'] * gimnasio['Repeticiones'] * gimnasio['Sets']
         total_volumen = gimnasio['Volumen'].sum()
         dias = usuario_datos['Dia'].nunique()
-        colm1, colm2 = st.columns(2)
+        gimnasio['Fecha'] = pd.to_datetime(gimnasio['Dia'], errors='coerce')
+        semanas = gimnasio['Fecha'].dt.to_period('W').nunique()
+        consistencia = dias / semanas if semanas else 0
+        colm1, colm2, colm3 = st.columns(3)
         colm1.metric('Volumen total', f"{total_volumen:.2f} kg")
         colm2.metric('Días registrados', dias)
+        colm3.metric('Consistencia (d/sem)', f"{consistencia:.1f}")
 
         gimnasio['1RM'] = gimnasio['Peso_kg'] * (1 + gimnasio['Repeticiones'] / 30)
         max_1rm = gimnasio.groupby('Ejercicio')['1RM'].max().reset_index(name='Proyección 1RM')
@@ -246,7 +252,6 @@ with tabs[1]:
         )
         st.altair_chart(graf_vol, use_container_width=True)
 
-        gimnasio['Fecha'] = pd.to_datetime(gimnasio['Dia'], errors='coerce')
         gimnasio['Semana'] = gimnasio['Fecha'].dt.to_period('W').astype(str)
         semanal = gimnasio.groupby('Semana')['Volumen'].sum().reset_index()
         st.subheader('Volumen semanal')
@@ -330,12 +335,19 @@ with tabs[2]:
         tipo_ej = st.selectbox('Tipo', ['Gimnasio', 'Carrera'])
         submitted = st.form_submit_button('Agregar')
         if submitted and grupo and ejercicio:
-            grupo_muscular_df.loc[len(grupo_muscular_df)] = [grupo, ejercicio, tipo_ej]
-            save_df(grupo_muscular_df, CATALOGO_CSV)
-            try:
-                st.experimental_rerun()
-            except Exception:
-                pass
+            existe = not grupo_muscular_df[
+                (grupo_muscular_df['Grupo_Muscular'] == grupo) &
+                (grupo_muscular_df['Ejercicio'] == ejercicio)
+            ].empty
+            if existe:
+                st.warning('El ejercicio ya existe')
+            else:
+                grupo_muscular_df.loc[len(grupo_muscular_df)] = [grupo, ejercicio, tipo_ej]
+                save_df(grupo_muscular_df, CATALOGO_CSV)
+                try:
+                    st.experimental_rerun()
+                except Exception:
+                    pass
     if not grupo_muscular_df.empty:
         borrar = st.selectbox('Eliminar ejercicio', grupo_muscular_df['Ejercicio'].unique())
         if st.button('Eliminar'):

--- a/main.py
+++ b/main.py
@@ -202,14 +202,23 @@ with tabs[1]:
         st.info('Aún no hay datos registrados')
     else:
         gimnasio = usuario_datos[usuario_datos['Tipo'] == 'Gimnasio'].copy()
-        gimnasio['Peso_kg'] = gimnasio.apply(lambda r: r['Peso'] if r['Unidad'] != 'lb' else r['Peso'] * 0.453592, axis=1)
+        gimnasio['Peso_kg'] = gimnasio.apply(
+            lambda r: r['Peso'] if r['Unidad'] != 'lb' else r['Peso'] * 0.453592,
+            axis=1,
+        )
+        gimnasio['Fecha'] = pd.to_datetime(gimnasio['Dia'], errors='coerce')
+        min_d, max_d = gimnasio['Fecha'].min(), gimnasio['Fecha'].max()
+        rango = st.date_input('Rango de fechas', [min_d, max_d])
+        if len(rango) == 2:
+            start, end = pd.to_datetime(rango[0]), pd.to_datetime(rango[1])
+            gimnasio = gimnasio[(gimnasio['Fecha'] >= start) & (gimnasio['Fecha'] <= end)]
+
         ejercicios_disp = ['Todos'] + sorted(gimnasio['Ejercicio'].unique())
         ejercicio_sel = st.selectbox('Filtrar por ejercicio', ejercicios_disp)
         datos = gimnasio if ejercicio_sel == 'Todos' else gimnasio[gimnasio['Ejercicio'] == ejercicio_sel]
         gimnasio['Volumen'] = gimnasio['Peso_kg'] * gimnasio['Repeticiones'] * gimnasio['Sets']
         total_volumen = gimnasio['Volumen'].sum()
         dias = usuario_datos['Dia'].nunique()
-        gimnasio['Fecha'] = pd.to_datetime(gimnasio['Dia'], errors='coerce')
         semanas = gimnasio['Fecha'].dt.to_period('W').nunique()
         consistencia = dias / semanas if semanas else 0
         colm1, colm2, colm3 = st.columns(3)
@@ -267,6 +276,21 @@ with tabs[1]:
         )
         st.altair_chart(graf_vol, use_container_width=True)
 
+        join = gimnasio.merge(
+            grupo_muscular_df[['Ejercicio', 'Grupo_Muscular']],
+            on='Ejercicio',
+            how='left',
+        )
+        grupo_vol = join.groupby('Grupo_Muscular')['Volumen'].sum().reset_index()
+        st.subheader('Volumen por grupo muscular')
+        graf_grupo = (
+            alt.Chart(grupo_vol)
+            .mark_bar()
+            .encode(x='Grupo_Muscular', y='Volumen', tooltip=['Volumen'])
+            .interactive()
+        )
+        st.altair_chart(graf_grupo, use_container_width=True)
+
         gimnasio['Semana'] = gimnasio['Fecha'].dt.to_period('W').astype(str)
         semanal = gimnasio.groupby('Semana')['Volumen'].sum().reset_index()
         st.subheader('Volumen semanal')
@@ -277,6 +301,21 @@ with tabs[1]:
             .interactive()
         )
         st.altair_chart(graf_sem, use_container_width=True)
+
+        avg_sem = gimnasio.groupby(['Semana', 'Ejercicio'])['Peso_kg'].mean().reset_index()
+        st.subheader('Peso promedio semanal')
+        graf_avg = (
+            alt.Chart(avg_sem)
+            .mark_line(point=True)
+            .encode(
+                x='Semana',
+                y='Peso_kg',
+                color='Ejercicio',
+                tooltip=['Semana', 'Ejercicio', 'Peso_kg'],
+            )
+            .interactive()
+        )
+        st.altair_chart(graf_avg, use_container_width=True)
 
         gimnasio['Mes'] = gimnasio['Fecha'].dt.to_period('M').astype(str)
         mensual = gimnasio.groupby('Mes')['Volumen'].sum().reset_index()

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ import pandas as pd
 import streamlit as st
 import altair as alt
 from datetime import date
+import time
 
 st.set_page_config(
     page_title="Gym & Running Tracker",
@@ -26,6 +27,8 @@ ound-color);}
 USUARIOS_CSV = 'data/Usuarios.csv'
 PROGRESO_CSV = 'data/Progreso.csv'
 CATALOGO_CSV = 'data/Grupo_muscular.csv'
+PESO_CSV = 'data/Peso.csv'
+RUTINAS_CSV = 'data/Rutinas.csv'
 
 
 def load_dfs():
@@ -49,14 +52,22 @@ def load_dfs():
         usuarios = pd.read_csv(USUARIOS_CSV)
     except FileNotFoundError:
         usuarios = pd.DataFrame(columns=['Id_Usuario', 'Nombre', 'Color', 'Username', 'Password'])
-    return progreso, catalogo, usuarios
+    try:
+        peso = pd.read_csv(PESO_CSV)
+    except FileNotFoundError:
+        peso = pd.DataFrame(columns=['Id_Usuario', 'Fecha', 'Peso', 'Cintura', 'Pecho', 'Foto'])
+    try:
+        rutina = pd.read_csv(RUTINAS_CSV)
+    except FileNotFoundError:
+        rutina = pd.DataFrame(columns=['Nombre', 'Ejercicio', 'Sets', 'Reps'])
+    return progreso, catalogo, usuarios, peso, rutina
 
 
 def save_df(df: pd.DataFrame, path: str):
     df.to_csv(path, index=False)
 
 
-progreso_df, grupo_muscular_df, usuario_df = load_dfs()
+progreso_df, grupo_muscular_df, usuario_df, peso_df, rutina_df = load_dfs()
 
 
 # ------ Autenticación ------
@@ -127,17 +138,28 @@ if st.session_state.get('next_workout'):
 
 st.title('🏋️‍♂️ Registro de Entrenamiento')
 
-tabs = st.tabs(['Registro', 'Progreso', 'Catálogo', 'Sincronización'])
+tabs = st.tabs([
+    'Registro',
+    'Progreso',
+    'Catálogo',
+    'Rutinas',
+    'Peso y Medidas',
+    'Calendario',
+    'Sincronización',
+])
 
 with tabs[0]:
     st.header('📝 Registrar Entrenamiento')
     tipo = st.selectbox('Tipo', ['Gimnasio', 'Carrera'])
     dia = st.date_input('Día', date.today())
     nota = st.text_area('Notas', key='nota')
+    rutina_sel = st.selectbox('Rutina', ['Ninguna'] + sorted(rutina_df['Nombre'].unique()))
+    if rutina_sel != 'Ninguna':
+        st.dataframe(rutina_df[rutina_df['Nombre'] == rutina_sel][['Ejercicio', 'Sets', 'Reps']])
     if tipo == 'Gimnasio':
         ejercicios = grupo_muscular_df[grupo_muscular_df['Tipo'] == 'Gimnasio']['Ejercicio']
         ejercicio = st.selectbox('Ejercicio', ejercicios.unique())
-        c1, c2, c3 = st.columns(3)
+        c1, c2, c3, c4 = st.columns(4)
         with c1:
             sets = st.number_input('Sets', min_value=1, max_value=10, step=1, value=4)
         with c2:
@@ -145,6 +167,8 @@ with tabs[0]:
             peso = st.number_input('Peso', min_value=0.0, step=0.1)
         with c3:
             reps = st.number_input('Repeticiones', min_value=1, step=1, value=10)
+        with c4:
+            descanso = st.slider('Descanso (s)', 30, 120, 60)
         if st.button('Guardar') and dia:
             dia_str = dia.strftime('%Y-%m-%d') if isinstance(dia, date) else str(dia)
             nuevo = pd.DataFrame({
@@ -163,6 +187,11 @@ with tabs[0]:
             progreso_df = pd.concat([progreso_df, nuevo], ignore_index=True)
             save_df(progreso_df, PROGRESO_CSV)
             st.success('Entrenamiento guardado')
+            place = st.empty()
+            for i in range(descanso, 0, -1):
+                place.write(f'Descanso... {i}s')
+                time.sleep(1)
+            place.write('¡Listo!')
     else:
         ejercicios = grupo_muscular_df[grupo_muscular_df['Tipo'] == 'Carrera']['Ejercicio']
         ejercicio = st.selectbox('Ejercicio', ejercicios.unique())
@@ -278,6 +307,25 @@ with tabs[1]:
         m4.metric('Último PR', ultimo_pr)
         m5.metric('Consistencia', f"{promedio_semana:.1f}/sem")
 
+        peso_user = peso_df[peso_df['Id_Usuario'] == st.session_state['user_id']]
+        if not peso_user.empty:
+            peso_user['Fecha'] = pd.to_datetime(peso_user['Fecha'])
+            peso_line = alt.Chart(peso_user).mark_line(point=True).encode(x='Fecha:T', y='Peso')
+            st.altair_chart(peso_line, use_container_width=True)
+
+        otros = st.multiselect('Comparar con', usuario_df['Nombre'])
+        if otros:
+            otros_ids = usuario_df[usuario_df['Nombre'].isin(otros)]['Id_Usuario']
+            comp = progreso_df[progreso_df['Id_Usuario'].isin(otros_ids) & (progreso_df['Tipo']=='Gimnasio')].copy()
+            if not comp.empty:
+                comp['Fecha'] = pd.to_datetime(comp['Dia'], errors='coerce')
+                comp['Peso_kg'] = comp.apply(lambda r: r['Peso'] if r['Unidad'] != 'lb' else r['Peso'] * 0.453592, axis=1)
+                comp['Volumen'] = comp['Peso_kg'] * comp['Repeticiones'] * comp['Sets']
+                resumen = comp.groupby(['Fecha','Id_Usuario'])['Volumen'].sum().reset_index()
+                resumen['Nombre'] = resumen['Id_Usuario'].map(usuario_df.set_index('Id_Usuario')['Nombre'])
+                chart_comp = alt.Chart(resumen).mark_line().encode(x='Fecha:T', y='Volumen', color='Nombre')
+                st.altair_chart(chart_comp, use_container_width=True)
+
         # --- Gráficas Gimnasio ---
         if show_gym and not gym.empty:
             claves = ['Press de pecho', 'Sentadilla', 'Peso muerto']
@@ -357,6 +405,70 @@ with tabs[2]:
                 pass
 
 with tabs[3]:
+    st.header('📓 Rutinas')
+    if not rutina_df.empty:
+        st.dataframe(rutina_df)
+    with st.form('add_routine'):
+        nombre_r = st.text_input('Nombre de la rutina')
+        ejercicio_r = st.selectbox('Ejercicio', grupo_muscular_df['Ejercicio'].unique())
+        sets_r = st.number_input('Sets', 1, 10, 1)
+        reps_r = st.number_input('Reps', 1, 50, 10)
+        if st.form_submit_button('Agregar a rutina') and nombre_r:
+            rutina_df.loc[len(rutina_df)] = [nombre_r, ejercicio_r, sets_r, reps_r]
+            save_df(rutina_df, RUTINAS_CSV)
+            st.success('Guardado')
+    if not rutina_df.empty:
+        borrar_r = st.selectbox('Eliminar entrada', rutina_df.index)
+        if st.button('Borrar entrada'):
+            rutina_df = rutina_df.drop(borrar_r)
+            save_df(rutina_df, RUTINAS_CSV)
+            st.experimental_rerun()
+
+with tabs[4]:
+    st.header('⚖️ Peso y Medidas')
+    peso_val = st.number_input('Peso (kg)', min_value=0.0, step=0.1)
+    cin = st.number_input('Cintura (cm)', min_value=0.0, step=0.1)
+    pecho = st.number_input('Pecho (cm)', min_value=0.0, step=0.1)
+    if st.button('Guardar peso'):
+        nuevo = pd.DataFrame({
+            'Id_Usuario': [st.session_state['user_id']],
+            'Fecha': [date.today().strftime('%Y-%m-%d')],
+            'Peso': [peso_val],
+            'Cintura': [cin if cin else None],
+            'Pecho': [pecho if pecho else None],
+            'Foto': [None],
+        })
+        peso_df = pd.concat([peso_df, nuevo], ignore_index=True)
+        save_df(peso_df, PESO_CSV)
+        st.success('Guardado')
+    if not peso_df.empty:
+        peso_user = peso_df[peso_df['Id_Usuario'] == st.session_state['user_id']]
+        if not peso_user.empty:
+            peso_user['Fecha'] = pd.to_datetime(peso_user['Fecha'])
+            line_peso = alt.Chart(peso_user).mark_line(point=True).encode(x='Fecha:T', y='Peso')
+            st.altair_chart(line_peso, use_container_width=True)
+
+with tabs[5]:
+    st.header('📅 Calendario')
+    cal_user = progreso_df[progreso_df['Id_Usuario'] == st.session_state['user_id']]
+    if cal_user.empty:
+        st.info('Sin registros')
+    else:
+        cal_user['Fecha'] = pd.to_datetime(cal_user['Dia'])
+        resumen = cal_user.groupby('Fecha').size().reset_index(name='sesiones')
+        resumen['dow'] = resumen['Fecha'].dt.day
+        resumen['month'] = resumen['Fecha'].dt.month
+        heat = alt.Chart(resumen).mark_rect().encode(
+            x=alt.X('dow:O', title='Día'),
+            y=alt.Y('month:O', title='Mes'),
+            color=alt.Color('sesiones:Q', scale=alt.Scale(scheme='greens')),
+            tooltip=['Fecha', 'sesiones'],
+        )
+        st.altair_chart(heat, use_container_width=True)
+        freq = resumen['Fecha'].dt.isocalendar().week.value_counts().mean()
+        st.metric('Frecuencia semanal', f'{freq:.1f} días')
+
+with tabs[6]:
     st.header('🔄 Sincronización')
     csv_data = progreso_df.to_csv(index=False).encode('utf-8')
     st.download_button('Descargar historial', csv_data, 'progreso.csv', 'text/csv')

--- a/main.py
+++ b/main.py
@@ -1,6 +1,13 @@
 import pandas as pd
 import streamlit as st
 import altair as alt
+from datetime import date
+
+st.set_page_config(
+    page_title="Gym & Running Tracker",
+    page_icon="🏃",
+    layout="centered",
+)
 
 USUARIOS_CSV = 'data/Usuarios.csv'
 PROGRESO_CSV = 'data/Progreso.csv'
@@ -92,42 +99,29 @@ if not st.session_state['authenticated']:
     register_form()
     st.stop()
 
-
 usuario_actual = usuario_df[usuario_df['Id_Usuario'] == st.session_state['user_id']].iloc[0]
 st.sidebar.write(f"Usuario: {usuario_actual['Nombre']}")
 st.sidebar.button('Cerrar sesión', on_click=logout)
 
+rem_date = st.sidebar.date_input(
+    'Próximo entrenamiento',
+    st.session_state.get('next_workout', date.today())
+)
+if st.sidebar.button('Guardar recordatorio'):
+    st.session_state['next_workout'] = rem_date
+    st.sidebar.success('Recordatorio guardado')
+if st.session_state.get('next_workout'):
+    st.sidebar.info(f"Próximo entrenamiento: {st.session_state['next_workout']}")
+
 st.title('🏋️‍♂️ Registro de Entrenamiento')
 
-# ------ Catálogo de Ejercicios ------
-with st.expander('📚 Catálogo de Ejercicios'):
-    st.dataframe(grupo_muscular_df)
-    with st.form('add_exercise'):
-        grupo = st.text_input('Grupo Muscular')
-        ejercicio = st.text_input('Ejercicio')
-        tipo_ej = st.selectbox('Tipo', ['Gimnasio', 'Carrera'])
-        submitted = st.form_submit_button('Agregar')
-        if submitted and grupo and ejercicio:
-            grupo_muscular_df.loc[len(grupo_muscular_df)] = [grupo, ejercicio, tipo_ej]
-            save_df(grupo_muscular_df, CATALOGO_CSV)
-            try:
-                st.experimental_rerun()
-            except Exception:
-                pass
-    if not grupo_muscular_df.empty:
-        borrar = st.selectbox('Eliminar ejercicio', grupo_muscular_df['Ejercicio'].unique())
-        if st.button('Eliminar'):
-            grupo_muscular_df = grupo_muscular_df[grupo_muscular_df['Ejercicio'] != borrar]
-            save_df(grupo_muscular_df, CATALOGO_CSV)
-            try:
-                st.experimental_rerun()
-            except Exception:
-                pass
+tabs = st.tabs(['Registro', 'Progreso', 'Catálogo', 'Sincronización'])
 
-# ------ Registro de entrenamiento ------
-with st.expander('📝 Registrar Entrenamiento'):
+with tabs[0]:
+    st.header('📝 Registrar Entrenamiento')
     tipo = st.selectbox('Tipo', ['Gimnasio', 'Carrera'])
     dia = st.text_input('Día')
+    nota = st.text_area('Notas', key='nota')
     if tipo == 'Gimnasio':
         ejercicios = grupo_muscular_df[grupo_muscular_df['Tipo'] == 'Gimnasio']['Ejercicio']
         ejercicio = st.selectbox('Ejercicio', ejercicios.unique())
@@ -157,6 +151,7 @@ with st.expander('📝 Registrar Entrenamiento'):
         ejercicio = st.selectbox('Ejercicio', ejercicios.unique())
         distancia = st.number_input('Distancia (km)', min_value=0.0, step=0.1)
         tiempo = st.number_input('Tiempo (min)', min_value=0.0, step=1.0)
+        ruta = st.file_uploader('Ruta GPX/CSV (opcional)', type=['gpx', 'csv'])
         if st.button('Guardar') and dia:
             nuevo = pd.DataFrame({
                 'Dia': [dia],
@@ -173,9 +168,16 @@ with st.expander('📝 Registrar Entrenamiento'):
             progreso_df = pd.concat([progreso_df, nuevo], ignore_index=True)
             save_df(progreso_df, PROGRESO_CSV)
             st.success('Entrenamiento guardado')
+        if ruta is not None:
+            try:
+                coords = pd.read_csv(ruta)
+                if {'lat', 'lon'}.issubset(coords.columns):
+                    st.map(coords[['lat', 'lon']])
+            except Exception:
+                pass
 
-# ------ Panel de progreso ------
-with st.expander('📊 Progreso'):
+with tabs[1]:
+    st.header('📊 Progreso')
     usuario_datos = progreso_df[progreso_df['Id_Usuario'] == st.session_state['user_id']]
     if usuario_datos.empty:
         st.info('Aún no hay datos registrados')
@@ -251,11 +253,51 @@ with st.expander('📊 Progreso'):
         graf_comp = alt.Chart(comp).mark_bar().encode(x='Nombre', y='Peso_kg')
         st.altair_chart(graf_comp, use_container_width=True)
 
-    with st.expander('🚧 En progreso'):
-        st.markdown(
-            '- Seguimiento de entrenamientos personalizados\n'
-            '- Módulo de running con GPS\n'
-            '- Notificaciones y recordatorios\n'
-            '- Sincronización con plataformas de salud'
-        )
+        with st.expander('🚧 En progreso'):
+            st.markdown(
+                '- Seguimiento de entrenamientos personalizados\n'
+                '- Módulo de running con GPS\n'
+                '- Notificaciones y recordatorios\n'
+                '- Sincronización con plataformas de salud'
+            )
+
+with tabs[2]:
+    st.header('📚 Catálogo de Ejercicios')
+    st.dataframe(grupo_muscular_df)
+    with st.form('add_exercise'):
+        grupo = st.text_input('Grupo Muscular')
+        ejercicio = st.text_input('Ejercicio')
+        tipo_ej = st.selectbox('Tipo', ['Gimnasio', 'Carrera'])
+        submitted = st.form_submit_button('Agregar')
+        if submitted and grupo and ejercicio:
+            grupo_muscular_df.loc[len(grupo_muscular_df)] = [grupo, ejercicio, tipo_ej]
+            save_df(grupo_muscular_df, CATALOGO_CSV)
+            try:
+                st.experimental_rerun()
+            except Exception:
+                pass
+    if not grupo_muscular_df.empty:
+        borrar = st.selectbox('Eliminar ejercicio', grupo_muscular_df['Ejercicio'].unique())
+        if st.button('Eliminar'):
+            grupo_muscular_df = grupo_muscular_df[grupo_muscular_df['Ejercicio'] != borrar]
+            save_df(grupo_muscular_df, CATALOGO_CSV)
+            try:
+                st.experimental_rerun()
+            except Exception:
+                pass
+
+with tabs[3]:
+    st.header('🔄 Sincronización')
+    csv_data = progreso_df.to_csv(index=False).encode('utf-8')
+    st.download_button('Descargar historial', csv_data, 'progreso.csv', 'text/csv')
+    archivo = st.file_uploader('Importar CSV', type='csv')
+    if archivo is not None:
+        try:
+            nuevos = pd.read_csv(archivo)
+            progreso_df = pd.concat([progreso_df, nuevos], ignore_index=True)
+            save_df(progreso_df, PROGRESO_CSV)
+            st.success('Datos importados')
+        except Exception as e:
+            st.error(f'Error al importar: {e}')
+
 

--- a/main.py
+++ b/main.py
@@ -53,7 +53,10 @@ def login_form():
         if not row.empty:
             st.session_state['authenticated'] = True
             st.session_state['user_id'] = row.iloc[0]['Id_Usuario']
-            st.experimental_rerun()
+            try:
+                st.experimental_rerun()
+            except Exception:
+                pass
         else:
             st.error('Credenciales inválidas')
 
@@ -77,7 +80,10 @@ def register_form():
 def logout():
     st.session_state['authenticated'] = False
     st.session_state['user_id'] = None
-    st.experimental_rerun()
+    try:
+        st.experimental_rerun()
+    except Exception:
+        pass
 
 
 if not st.session_state['authenticated']:
@@ -104,13 +110,19 @@ with st.expander('📚 Catálogo de Ejercicios'):
         if submitted and grupo and ejercicio:
             grupo_muscular_df.loc[len(grupo_muscular_df)] = [grupo, ejercicio, tipo_ej]
             save_df(grupo_muscular_df, CATALOGO_CSV)
-            st.experimental_rerun()
+            try:
+                st.experimental_rerun()
+            except Exception:
+                pass
     if not grupo_muscular_df.empty:
         borrar = st.selectbox('Eliminar ejercicio', grupo_muscular_df['Ejercicio'].unique())
         if st.button('Eliminar'):
             grupo_muscular_df = grupo_muscular_df[grupo_muscular_df['Ejercicio'] != borrar]
             save_df(grupo_muscular_df, CATALOGO_CSV)
-            st.experimental_rerun()
+            try:
+                st.experimental_rerun()
+            except Exception:
+                pass
 
 # ------ Registro de entrenamiento ------
 with st.expander('📝 Registrar Entrenamiento'):
@@ -176,6 +188,11 @@ with st.expander('📊 Progreso'):
         st.metric('Volumen total', f"{total_volumen:.2f} kg")
         st.metric('Días registrados', dias)
 
+        gimnasio['1RM'] = gimnasio['Peso_kg'] * (1 + gimnasio['Repeticiones'] / 30)
+        max_1rm = gimnasio.groupby('Ejercicio')['1RM'].max().reset_index(name='Proyección 1RM')
+        st.subheader('Proyección de 1RM por ejercicio')
+        st.dataframe(max_1rm)
+
         pr = gimnasio.groupby('Ejercicio')['Peso_kg'].max().reset_index(name='PR (kg)')
         st.subheader('Récords personales')
         st.dataframe(pr)
@@ -189,6 +206,23 @@ with st.expander('📊 Progreso'):
         )
         st.altair_chart(grafica, use_container_width=True)
 
+        gimnasio['Fecha'] = pd.to_datetime(gimnasio['Dia'], errors='coerce')
+        gimnasio['Semana'] = gimnasio['Fecha'].dt.to_period('W').astype(str)
+        semanal = gimnasio.groupby('Semana')['Volumen'].sum().reset_index()
+        st.subheader('Volumen semanal')
+        graf_sem = alt.Chart(semanal).mark_line(point=True).encode(
+            x='Semana', y='Volumen'
+        )
+        st.altair_chart(graf_sem, use_container_width=True)
+
+        gimnasio['Mes'] = gimnasio['Fecha'].dt.to_period('M').astype(str)
+        mensual = gimnasio.groupby('Mes')['Volumen'].sum().reset_index()
+        st.subheader('Volumen mensual')
+        graf_mens = alt.Chart(mensual).mark_bar().encode(
+            x='Mes', y='Volumen'
+        )
+        st.altair_chart(graf_mens, use_container_width=True)
+
         carreras = usuario_datos[usuario_datos['Tipo'] == 'Carrera']
         if not carreras.empty:
             total_km = carreras['Distancia'].sum()
@@ -197,6 +231,15 @@ with st.expander('📊 Progreso'):
                 x='Dia:T', y='Distancia', color='Ejercicio'
             )
             st.altair_chart(graf_km, use_container_width=True)
+
+            carreras['Fecha'] = pd.to_datetime(carreras['Dia'], errors='coerce')
+            carreras['Semana'] = carreras['Fecha'].dt.to_period('W').astype(str)
+            run_sem = carreras.groupby('Semana')['Distancia'].sum().reset_index()
+            st.subheader('Distancia semanal')
+            graf_run_sem = alt.Chart(run_sem).mark_line(point=True).encode(
+                x='Semana', y='Distancia'
+            )
+            st.altair_chart(graf_run_sem, use_container_width=True)
 
         st.subheader('Comparativa con otros usuarios')
         ejercicio_comp = st.selectbox('Ejercicio', progreso_df['Ejercicio'].unique())
@@ -207,4 +250,12 @@ with st.expander('📊 Progreso'):
         comp = comp.merge(usuario_df[['Id_Usuario', 'Nombre']], on='Id_Usuario')
         graf_comp = alt.Chart(comp).mark_bar().encode(x='Nombre', y='Peso_kg')
         st.altair_chart(graf_comp, use_container_width=True)
+
+    with st.expander('🚧 En progreso'):
+        st.markdown(
+            '- Seguimiento de entrenamientos personalizados\n'
+            '- Módulo de running con GPS\n'
+            '- Notificaciones y recordatorios\n'
+            '- Sincronización con plataformas de salud'
+        )
 

--- a/main.py
+++ b/main.py
@@ -27,7 +27,7 @@ CATALOGO_CSV = 'data/Grupo_muscular.csv'
 
 def load_dfs():
     cols = ['Dia', 'Id_Usuario', 'Ejercicio', 'Peso', 'Sets',
-            'Repeticiones', 'Unidad', 'Distancia', 'Tipo', 'Tiempo']
+            'Repeticiones', 'Unidad', 'Distancia', 'Tipo', 'Tiempo', 'Notas']
     try:
         progreso = pd.read_csv(PROGRESO_CSV)
         for c in cols:
@@ -144,18 +144,18 @@ with tabs[0]:
             reps = st.number_input('Repeticiones', min_value=1, step=1, value=10)
         if st.button('Guardar') and dia:
             dia_str = dia.strftime('%Y-%m-%d') if isinstance(dia, date) else str(dia)
-            peso_kg = peso * 0.453592 if unidad == 'lb' else peso
             nuevo = pd.DataFrame({
                 'Dia': [dia_str],
                 'Id_Usuario': [st.session_state['user_id']],
                 'Ejercicio': [ejercicio],
-                'Peso': [peso_kg],
+                'Peso': [peso],
                 'Sets': [sets],
                 'Repeticiones': [reps],
                 'Unidad': [unidad],
                 'Distancia': [None],
                 'Tipo': ['Gimnasio'],
-                'Tiempo': [None]
+                'Tiempo': [None],
+                'Notas': [nota]
             })
             progreso_df = pd.concat([progreso_df, nuevo], ignore_index=True)
             save_df(progreso_df, PROGRESO_CSV)
@@ -181,7 +181,8 @@ with tabs[0]:
                 'Unidad': ['km'],
                 'Distancia': [distancia],
                 'Tipo': ['Carrera'],
-                'Tiempo': [tiempo]
+                'Tiempo': [tiempo],
+                'Notas': [nota]
             })
             progreso_df = pd.concat([progreso_df, nuevo], ignore_index=True)
             save_df(progreso_df, PROGRESO_CSV)
@@ -224,10 +225,24 @@ with tabs[1]:
         pr = gimnasio.groupby('Ejercicio')['Peso_kg'].max().reset_index(name='PR (kg)')
         st.subheader('Récords personales')
         st.dataframe(pr)
+        pr_chart = (
+            alt.Chart(pr)
+            .mark_bar()
+            .encode(x='Ejercicio', y='PR (kg)', tooltip=['PR (kg)'])
+            .interactive()
+        )
+        st.altair_chart(pr_chart, use_container_width=True)
 
         st.subheader('Peso promedio por ejercicio')
         promedio = gimnasio.groupby('Ejercicio')['Peso_kg'].mean().reset_index(name='Promedio (kg)')
         st.dataframe(promedio)
+        prom_chart = (
+            alt.Chart(promedio)
+            .mark_bar()
+            .encode(x='Ejercicio', y='Promedio (kg)', tooltip=['Promedio (kg)'])
+            .interactive()
+        )
+        st.altair_chart(prom_chart, use_container_width=True)
 
         grafica = (
             alt.Chart(datos)

--- a/main.py
+++ b/main.py
@@ -214,8 +214,16 @@ with tabs[1]:
         elif rango_opt == '30 días':
             inicio, fin = hoy - pd.Timedelta(days=29), hoy
         else:
-            r = st.date_input('Selecciona rango', [data_user['Fecha'].min(), data_user['Fecha'].max()])
-            inicio, fin = pd.to_datetime(r[0]), pd.to_datetime(r[1]) if len(r) == 2 else (data_user['Fecha'].min(), data_user['Fecha'].max())
+            r = st.date_input(
+                'Selecciona rango',
+                value=[data_user['Fecha'].min(), data_user['Fecha'].max()],
+            )
+            if len(r) == 2:
+                inicio = pd.to_datetime(r[0])
+                fin = pd.to_datetime(r[1])
+            else:
+                inicio = data_user['Fecha'].min()
+                fin = data_user['Fecha'].max()
         periodo = (fin - inicio).days + 1
         datos_periodo = data_user[(data_user['Fecha'] >= inicio) & (data_user['Fecha'] <= fin)]
         prev = data_user[(data_user['Fecha'] >= inicio - pd.Timedelta(days=periodo)) & (data_user['Fecha'] < inicio)]

--- a/main.py
+++ b/main.py
@@ -1,174 +1,139 @@
-# Importamos librerías
 import pandas as pd
 import streamlit as st
-from pathlib import Path
-from base64 import b64encode
 import altair as alt
 
-# Cargar datos
-try:
-    progreso_df = pd.read_csv('data/Progreso.csv')
-    grupo_muscular_df = pd.read_csv('data/Grupo_muscular.csv')
-    usuario_df = pd.read_csv('data/Usuarios.csv')
-except FileNotFoundError as e:
-    st.error(f"Error al cargar archivos: {e}")
-
-# Unir las tablas
-progreso_df = progreso_df.merge(grupo_muscular_df, on='Maquina')
-progreso_df = progreso_df.merge(usuario_df, on='Id_Usuario')
-
-# Funciones
-def formulario_desarrollo_fuerza(Sets):
-    pesos = []
-    for i in range(Sets):
-        peso = st.number_input(f'💪 Peso para el Set {i+1}:', min_value=0.0, step=0.1, format="%.1f")
-        pesos.append(peso)
-    repeticiones = st.number_input('Repeticiones:', min_value=1, max_value=30, step=1)
-    descanso = st.selectbox('Tiempo de descanso:', ('1-2 min', '2-3 min', '3-4 min'))
-    return pesos, [repeticiones] * Sets, [descanso] * Sets
-
-def formulario_mejora_resistencia(Sets):
-    pesos = []
-    for i in range(Sets):
-        peso = st.number_input(f'💪 Peso para el Set {i+1}:', min_value=0.0, step=0.1, format="%.1f")
-        pesos.append(peso)
-    repeticiones = [st.number_input(f'🏃 Repeticiones para el Set {i+1}:', min_value=1, max_value=30, step=1) for i in range(Sets)]
-    descanso = st.selectbox('Tiempo de descanso:', ('1-2 min', '2-3 min', '3-4 min'))
-    return pesos, repeticiones, [descanso] * Sets
-
-def formulario_hipertrofia_muscular(Sets):
-    peso = st.number_input('💪 Peso (kg):', min_value=0.0, step=0.1, format="%.1f")
-    repeticiones = st.number_input('Repeticiones:', min_value=1, max_value=30, step=1)
-    descanso = st.selectbox('Tiempo de descanso:', ('1-2 min', '2-3 min', '3-4 min'))
-    return [peso] * Sets, [repeticiones] * Sets, [descanso] * Sets
-
-def download_csv(df, filename):
-    csv = df.to_csv(index=False).encode('utf-8')
-    b64 = b64encode(csv).decode()
-    href = f'<a href="data:file/csv;base64,{b64}" download="{filename}.csv">Descargar {filename}</a>'
-    return href
-
-def calcular_promedio(df):    
-    df['Sets_x_Reps'] = df['Sets'] * df['Repeticiones']
-    df['Peso_Total'] = df['Peso'] * df['Sets'] * df['Repeticiones']
-    df['Suma_Repeticiones'] = df.groupby(['Id_Usuario', 'Dia'])['Repeticiones'].transform('sum')
-    promedio_ponderado_por_persona = df.groupby(['Id_Usuario', 'Dia']).apply(
-        lambda x: x['Peso_Total'].sum() / x['Sets_x_Reps'].sum()
-    ).reset_index(name='Promedio_Ponderado')
-    resultado_final = df[['Id_Usuario', 'Dia', 'Suma_Repeticiones']].drop_duplicates().merge(
-        promedio_ponderado_por_persona, on=['Id_Usuario', 'Dia'])
-    return resultado_final
+USUARIOS_CSV = 'data/Usuarios.csv'
+PROGRESO_CSV = 'data/Progreso.csv'
+CATALOGO_CSV = 'data/Grupo_muscular.csv'
 
 
-def crear_graficos(df_grupo, colores):
-    df_grupo = df_grupo.reset_index(drop=True)
-    if len(df_grupo) == 0:
-        st.warning("No hay suficientes datos disponibles para mostrar los gráficos.")
-        return
+def load_dfs():
+    try:
+        progreso = pd.read_csv(PROGRESO_CSV)
+    except FileNotFoundError:
+        progreso = pd.DataFrame(columns=['Dia', 'Id_Usuario', 'Ejercicio', 'Peso', 'Sets', 'Repeticiones'])
+    try:
+        catalogo = pd.read_csv(CATALOGO_CSV)
+    except FileNotFoundError:
+        catalogo = pd.DataFrame(columns=['Grupo_Muscular', 'Ejercicio'])
+    try:
+        usuarios = pd.read_csv(USUARIOS_CSV)
+    except FileNotFoundError:
+        usuarios = pd.DataFrame(columns=['Id_Usuario', 'Nombre', 'Color', 'Username', 'Password'])
+    return progreso, catalogo, usuarios
 
-    resultado_final = calcular_promedio(df_grupo)
-    resultado_final = resultado_final.merge(usuario_df[['Id_Usuario', 'Nombre']], on='Id_Usuario')
 
-    # Gráfico de promedio de peso levantado
-    line_chart = alt.Chart(resultado_final).mark_line().encode(
-        x='Dia_ordenado:T',
-        y=alt.Y('Promedio_Ponderado', title='Promedio de Peso'),
-        color=alt.Color('Nombre:N', scale=alt.Scale(domain=['Carlos', 'Cinthia'], range=['black', 'lightblue']), title='Persona'),
-        tooltip=['Nombre', 'Dia', 'Promedio_Ponderado']
-    ).properties(
-        title="Promedio de Peso Levantado"
-    )
-    st.altair_chart(line_chart, use_container_width=True)
+def save_df(df: pd.DataFrame, path: str):
+    df.to_csv(path, index=False)
 
-    # Gráfico de total de repeticiones
-    bar_chart = alt.Chart(resultado_final).mark_bar().encode(
-        x='Dia_ordenado:T',
-        y=alt.Y('Suma_Repeticiones', title='Total de Repeticiones'),
-        color=alt.Color('Nombre:N', scale=alt.Scale(domain=['Carlos', 'Cinthia'], range=['black', 'lightblue']), title='Persona'),
-        tooltip=['Nombre', 'Dia', 'Suma_Repeticiones']
-    ).properties(
-        title="Total de Repeticiones"
-    )
-    st.altair_chart(bar_chart, use_container_width=True)
 
-    # Gráficos por grupo muscular
-    if 'Grupo_Muscular' in df_grupo.columns:
-        grupos_musculares = df_grupo['Grupo_Muscular'].unique().tolist()
-        for grupo in grupos_musculares:
-            df_grupo_grupo = df_grupo[df_grupo['Grupo_Muscular'] == grupo]
-            if not df_grupo_grupo.empty:
-                grafica_grupo_muscular = alt.Chart(df_grupo_grupo).mark_line().encode(
-                    x='Dia_ordenado:T',
-                    y='Peso:Q',
-                    color='Nombre:N',
-                    tooltip=['Dia', 'Peso', 'Nombre']
-                ).properties(
-                    title=f"Progreso por {grupo}"
-                )
-                st.altair_chart(grafica_grupo_muscular, use_container_width=True)
-            else:
-                st.warning(f"No hay suficientes datos disponibles para mostrar el gráfico de {grupo}.")
+progreso_df, grupo_muscular_df, usuario_df = load_dfs()
+
+
+# ------ Autenticación ------
+if 'authenticated' not in st.session_state:
+    st.session_state['authenticated'] = False
+    st.session_state['user_id'] = None
+
+
+def login_form():
+    st.header('Iniciar sesión')
+    user = st.text_input('Usuario')
+    pwd = st.text_input('Contraseña', type='password')
+    if st.button('Ingresar'):
+        row = usuario_df[(usuario_df['Username'] == user) & (usuario_df['Password'] == pwd)]
+        if not row.empty:
+            st.session_state['authenticated'] = True
+            st.session_state['user_id'] = row.iloc[0]['Id_Usuario']
+            st.experimental_rerun()
+        else:
+            st.error('Credenciales inválidas')
+
+
+def register_form():
+    st.header('Registro')
+    name = st.text_input('Nombre para mostrar')
+    user = st.text_input('Usuario', key='reg_user')
+    pwd = st.text_input('Contraseña', type='password', key='reg_pwd')
+    if st.button('Registrar'):
+        if user in usuario_df['Username'].values:
+            st.error('El usuario ya existe')
+        else:
+            new_id = f'U{len(usuario_df) + 1}'
+            new_row = {'Id_Usuario': new_id, 'Nombre': name, 'Color': 'gray', 'Username': user, 'Password': pwd}
+            usuario_df.loc[len(usuario_df)] = new_row
+            save_df(usuario_df, USUARIOS_CSV)
+            st.success('Usuario registrado, ahora puede iniciar sesión')
+
+
+def logout():
+    st.session_state['authenticated'] = False
+    st.session_state['user_id'] = None
+    st.experimental_rerun()
+
+
+if not st.session_state['authenticated']:
+    login_form()
+    st.divider()
+    register_form()
+    st.stop()
+
+
+usuario_actual = usuario_df[usuario_df['Id_Usuario'] == st.session_state['user_id']].iloc[0]
+st.sidebar.write(f"Usuario: {usuario_actual['Nombre']}")
+st.sidebar.button('Cerrar sesión', on_click=logout)
+
+st.title('🏋️‍♂️ Registro de Entrenamiento')
+
+# ------ Catálogo de Ejercicios ------
+with st.expander('📚 Catálogo de Ejercicios'):
+    st.dataframe(grupo_muscular_df)
+    with st.form('add_exercise'):
+        grupo = st.text_input('Grupo Muscular')
+        ejercicio = st.text_input('Ejercicio')
+        submitted = st.form_submit_button('Agregar')
+        if submitted and grupo and ejercicio:
+            grupo_muscular_df.loc[len(grupo_muscular_df)] = [grupo, ejercicio]
+            save_df(grupo_muscular_df, CATALOGO_CSV)
+            st.experimental_rerun()
+    if not grupo_muscular_df.empty:
+        borrar = st.selectbox('Eliminar ejercicio', grupo_muscular_df['Ejercicio'].unique())
+        if st.button('Eliminar'):
+            grupo_muscular_df = grupo_muscular_df[grupo_muscular_df['Ejercicio'] != borrar]
+            save_df(grupo_muscular_df, CATALOGO_CSV)
+            st.experimental_rerun()
+
+# ------ Registro de entrenamiento ------
+with st.expander('📝 Registrar Entrenamiento'):
+    dia = st.text_input('Día')
+    ejercicio = st.selectbox('Ejercicio', grupo_muscular_df['Ejercicio'].unique())
+    sets = st.number_input('Sets', min_value=1, max_value=10, step=1, value=4)
+    peso = st.number_input('Peso', min_value=0.0, step=0.1)
+    reps = st.number_input('Repeticiones', min_value=1, step=1, value=10)
+    if st.button('Guardar') and dia:
+        nuevo = pd.DataFrame({'Dia': [dia], 'Id_Usuario': [st.session_state['user_id']],
+                             'Ejercicio': [ejercicio], 'Peso': [peso], 'Sets': [sets],
+                             'Repeticiones': [reps]})
+        progreso_df = pd.concat([progreso_df, nuevo], ignore_index=True)
+        save_df(progreso_df, PROGRESO_CSV)
+        st.success('Entrenamiento guardado')
+
+# ------ Panel de progreso ------
+with st.expander('📊 Progreso'):
+    usuario_datos = progreso_df[progreso_df['Id_Usuario'] == st.session_state['user_id']]
+    if usuario_datos.empty:
+        st.info('Aún no hay datos registrados')
     else:
-        st.warning("No se encontró la columna 'Grupo_Muscular' en el DataFrame.")
+        usuario_datos['Volumen'] = usuario_datos['Peso'] * usuario_datos['Repeticiones'] * usuario_datos['Sets']
+        total_volumen = usuario_datos['Volumen'].sum()
+        dias = usuario_datos['Dia'].nunique()
+        st.metric('Volumen total', f"{total_volumen:.2f}")
+        st.metric('Días registrados', dias)
+        pr = usuario_datos.groupby('Ejercicio')['Peso'].max().reset_index(name='PR')
+        st.subheader('Récords personales')
+        st.dataframe(pr)
+        grafica = alt.Chart(usuario_datos).mark_line().encode(
+            x='Dia:T', y='Peso', color='Ejercicio'
+        )
+        st.altair_chart(grafica, use_container_width=True)
 
-
-# Título de la aplicación
-st.title('🏋️‍♂️ Nuestro Progreso en el Gym 🏋️‍♀️')
-
-# Formulario desplegable y botón de guardar
-with st.expander('📝 Registro de Datos'):
-    Dia = st.text_input('Ingresa el Día 📆:')
-    Persona = st.selectbox('Selecciona tu nombre 🤵‍♂️🙍:', usuario_df['Nombre'].unique())
-    Maquina = st.selectbox('Selecciona una máquina 🏋️‍♀️🏋️‍♂️:', grupo_muscular_df['Maquina'].unique())
-    Enfoque = st.selectbox('Selecciona el enfoque de entrenamiento:', ('Desarrollo de Fuerza', 'Mejora de la Resistencia', 'Hipertrofia Muscular'))
-    Sets = st.number_input('Número de Sets:', min_value=1, max_value=10, step=1, value=4)
-    
-    if Enfoque == 'Desarrollo de Fuerza':
-        pesos, repeticiones, descansos = formulario_desarrollo_fuerza(Sets)
-    elif Enfoque == 'Mejora de la Resistencia':
-        pesos, repeticiones, descansos = formulario_mejora_resistencia(Sets)
-    else:
-        pesos, repeticiones, descansos = formulario_hipertrofia_muscular(Sets)
-        
-    form_completo = all(pesos) and all(repeticiones) and all(descansos)
-    
-    if form_completo:
-        if st.button('Guardar'):
-            progreso_new = pd.DataFrame({
-                'Dia': [Dia] * Sets,
-                'Id_Usuario': usuario_df[usuario_df['Nombre'] == Persona]['Id_Usuario'].values[0],
-                'Maquina': [Maquina] * Sets,
-                'Sets': [Sets] * Sets,
-                'Peso': pesos,
-                'Repeticiones': repeticiones,
-                'Descanso': descansos
-            })
-            progreso_df = pd.concat([progreso_df, progreso_new], ignore_index=True)
-            progreso_df.to_csv('/mnt/data/Progreso.csv', index=False)
-            st.success('¡Datos registrados con éxito!')
-            st.markdown(download_csv(progreso_df, 'Progreso_Actualizado'), unsafe_allow_html=True)
-
-# Visualización de datos registrados
-with st.expander('📓 Datos Registrados'):
-    st.subheader("Visualización de datos registrados")
-    datos_visualizacion = progreso_df[['Dia', 'Nombre', 'Maquina', 'Sets', 'Repeticiones']]
-    st.dataframe(datos_visualizacion)
-    st.markdown(download_csv(progreso_df, 'Progreso_Completo'), unsafe_allow_html=True)
-
-# Visualización de gráficos
-with st.expander('📊 Visualización de Gráficos'):
-    st.subheader("Datos de Gráficos por Persona y Maquina")
-    opcion_persona = st.selectbox('Selecciona una persona para graficar:', usuario_df['Nombre'].unique())
-    progreso_persona = progreso_df[progreso_df['Nombre'] == opcion_persona]
-    crear_graficos(progreso_persona, colores={'Carlos': 'black', 'Cinthia': 'lightblue'})
-    
-    # Gráficos por grupo muscular
-    st.subheader("Datos de Gráficos por Grupo Muscular")
-    if 'Grupo_Muscular' in progreso_df.columns:
-        grupos_musculares = progreso_df['Grupo_Muscular'].unique().tolist()
-        for grupo in grupos_musculares:
-            st.write(f"Grupo Muscular: {grupo}")
-            progreso_grupo = progreso_df[progreso_df['Grupo_Muscular'] == grupo]
-            crear_graficos(progreso_grupo, colores={'Carlos': 'black', 'Cinthia': 'lightblue'})
-    else:
-        st.warning("No hay suficientes datos disponibles para mostrar los gráficos por grupo muscular.")

--- a/main.py
+++ b/main.py
@@ -184,6 +184,9 @@ with tabs[1]:
     else:
         gimnasio = usuario_datos[usuario_datos['Tipo'] == 'Gimnasio'].copy()
         gimnasio['Peso_kg'] = gimnasio.apply(lambda r: r['Peso'] if r['Unidad'] != 'lb' else r['Peso'] * 0.453592, axis=1)
+        ejercicios_disp = ['Todos'] + sorted(gimnasio['Ejercicio'].unique())
+        ejercicio_sel = st.selectbox('Filtrar por ejercicio', ejercicios_disp)
+        datos = gimnasio if ejercicio_sel == 'Todos' else gimnasio[gimnasio['Ejercicio'] == ejercicio_sel]
         gimnasio['Volumen'] = gimnasio['Peso_kg'] * gimnasio['Repeticiones'] * gimnasio['Sets']
         total_volumen = gimnasio['Volumen'].sum()
         dias = usuario_datos['Dia'].nunique()
@@ -203,10 +206,17 @@ with tabs[1]:
         promedio = gimnasio.groupby('Ejercicio')['Peso_kg'].mean().reset_index(name='Promedio (kg)')
         st.dataframe(promedio)
 
-        grafica = alt.Chart(gimnasio).mark_line().encode(
+        grafica = alt.Chart(datos).mark_line().encode(
             x='Dia:T', y='Peso_kg', color='Ejercicio'
         )
         st.altair_chart(grafica, use_container_width=True)
+
+        volumen_ej = gimnasio.groupby('Ejercicio')['Volumen'].sum().reset_index()
+        st.subheader('Volumen total por ejercicio')
+        graf_vol = alt.Chart(volumen_ej).mark_bar().encode(
+            x='Ejercicio', y='Volumen'
+        )
+        st.altair_chart(graf_vol, use_container_width=True)
 
         gimnasio['Fecha'] = pd.to_datetime(gimnasio['Dia'], errors='coerce')
         gimnasio['Semana'] = gimnasio['Fecha'].dt.to_period('W').astype(str)

--- a/reset_data.py
+++ b/reset_data.py
@@ -1,0 +1,12 @@
+import pandas as pd
+
+USERS_CSV = 'data/Usuarios.csv'
+
+COLUMNS = ['Id_Usuario', 'Nombre', 'Color', 'Username', 'Password']
+
+def reset_users():
+    pd.DataFrame(columns=COLUMNS).to_csv(USERS_CSV, index=False)
+
+if __name__ == '__main__':
+    reset_users()
+    print('Datos de usuarios reiniciados')


### PR DESCRIPTION
## Summary
- add login and registration forms
- store user credentials in `Usuarios.csv`
- simplify catalog structure and make it editable
- update progress logging with new fields
- show progress metrics like volume and personal records

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686843dfd300832cb4a887c4e1108e9f